### PR TITLE
fix remove Strict-Transport-Security header from response

### DIFF
--- a/src/utils/returnHttpResponse.ts
+++ b/src/utils/returnHttpResponse.ts
@@ -1,4 +1,4 @@
 export function returnHttpResponse(oldResponse: Response): Response {
-  // todo CSP headers
+  oldResponse.headers.delete('Strict-Transport-Security')
   return oldResponse
 }


### PR DESCRIPTION
This header can break the websites that are not capable of using HTTPS