### PR TITLE
feat: better router and tests

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -1,6 +1,5 @@
 import { getScriptDownloadPath, getGetResultPath, getHealthCheckPath, WorkerEnv, getStatusPagePath } from './env'
 
-import { createErrorResponseForIngress, createErrorResponseForProCDN } from './utils'
 import { handleDownloadScript, handleIngressAPI, handleHealthCheck, handleStatusPage } from './handlers'
 import { createRoute } from './utils'
 
@@ -13,23 +12,11 @@ function createRoutes(env: WorkerEnv): Route[] {
   const routes: Route[] = []
   const downloadScriptRoute: Route = {
     pathPattern: createRoute(getScriptDownloadPath(env)),
-    handler: async (request) => {
-      try {
-        return await handleDownloadScript(request)
-      } catch (e) {
-        return createErrorResponseForProCDN(e)
-      }
-    },
+    handler: handleDownloadScript,
   }
   const ingressAPIRoute: Route = {
     pathPattern: createRoute(getGetResultPath(env)),
-    handler: async (request, env) => {
-      try {
-        return await handleIngressAPI(request, env)
-      } catch (e) {
-        return createErrorResponseForIngress(request, e)
-      }
-    },
+    handler: handleIngressAPI,
   }
   const healthRoute: Route = {
     pathPattern: createRoute(getHealthCheckPath(env)),

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -2,7 +2,7 @@ import { getScriptDownloadPath, getGetResultPath, getHealthCheckPath, WorkerEnv,
 
 import { createErrorResponseForIngress, createErrorResponseForProCDN } from './utils'
 import { handleDownloadScript, handleIngressAPI, handleHealthCheck, handleStatusPage } from './handlers'
-import { createRoute } from './utils/routing'
+import { createRoute } from './utils'
 
 export async function handleRequest(request: Request, env: WorkerEnv): Promise<Response> {
   const url = new URL(request.url)

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -1,13 +1,14 @@
 import { getScriptDownloadPath, getGetResultPath, getHealthCheckPath, WorkerEnv, getStatusPagePath } from './env'
 
-import { createErrorResponseForIngress, createErrorResponseForProCDN, removeTrailingSlashes } from './utils'
+import { createErrorResponseForIngress, createErrorResponseForProCDN } from './utils'
 import { handleDownloadScript, handleIngressAPI, handleHealthCheck, handleStatusPage } from './handlers'
+import { createRoute } from './utils/routing'
 
 export async function handleRequest(request: Request, env: WorkerEnv): Promise<Response> {
   const url = new URL(request.url)
-  const pathname = removeTrailingSlashes(url.pathname)
 
-  if (pathname === getScriptDownloadPath(env)) {
+  const scriptDownloadRoute = createRoute(getScriptDownloadPath(env))
+  if (url.pathname.match(scriptDownloadRoute)) {
     try {
       return await handleDownloadScript(request)
     } catch (e) {
@@ -15,7 +16,8 @@ export async function handleRequest(request: Request, env: WorkerEnv): Promise<R
     }
   }
 
-  if (pathname === getGetResultPath(env)) {
+  const getResultRoute = createRoute(getGetResultPath(env))
+  if (url.pathname.match(getResultRoute)) {
     try {
       return await handleIngressAPI(request, env)
     } catch (e) {
@@ -23,13 +25,15 @@ export async function handleRequest(request: Request, env: WorkerEnv): Promise<R
     }
   }
 
-  if (pathname === getHealthCheckPath(env)) {
+  const healthRoute = createRoute(getHealthCheckPath(env))
+  if (url.pathname.match(healthRoute)) {
     return handleHealthCheck(env)
   }
 
-  if (pathname === getStatusPagePath(env)) {
+  const statusRoute = createRoute(getStatusPagePath(env))
+  if (url.pathname.match(statusRoute)) {
     return handleStatusPage(env)
   }
 
-  return new Response(JSON.stringify({ error: `unmatched path ${pathname}` }), { status: 404 })
+  return new Response(JSON.stringify({ error: `unmatched path ${url.pathname}` }), { status: 404 })
 }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -4,36 +4,61 @@ import { createErrorResponseForIngress, createErrorResponseForProCDN } from './u
 import { handleDownloadScript, handleIngressAPI, handleHealthCheck, handleStatusPage } from './handlers'
 import { createRoute } from './utils'
 
-export async function handleRequest(request: Request, env: WorkerEnv): Promise<Response> {
+export type Route = {
+  pathPattern: RegExp
+  handler: (request: Request, env: WorkerEnv) => Response | Promise<Response>
+}
+
+function createRoutes(env: WorkerEnv): Route[] {
+  const routes: Route[] = []
+  const downloadScriptRoute: Route = {
+    pathPattern: createRoute(getScriptDownloadPath(env)),
+    handler: async (request) => {
+      try {
+        return await handleDownloadScript(request)
+      } catch (e) {
+        return createErrorResponseForProCDN(e)
+      }
+    },
+  }
+  const ingressAPIRoute: Route = {
+    pathPattern: createRoute(getGetResultPath(env)),
+    handler: async (request, env) => {
+      try {
+        return await handleIngressAPI(request, env)
+      } catch (e) {
+        return createErrorResponseForIngress(request, e)
+      }
+    },
+  }
+  const healthRoute: Route = {
+    pathPattern: createRoute(getHealthCheckPath(env)),
+    handler: (_, env) => handleHealthCheck(env),
+  }
+  const statusRoute: Route = {
+    pathPattern: createRoute(getStatusPagePath(env)),
+    handler: (request, env) => handleStatusPage(request, env),
+  }
+  routes.push(downloadScriptRoute)
+  routes.push(ingressAPIRoute)
+  routes.push(healthRoute)
+  routes.push(statusRoute)
+
+  return routes
+}
+
+export async function handleRequestWithRoutes(request: Request, env: WorkerEnv, routes: Route[]): Promise<Response> {
   const url = new URL(request.url)
-
-  const scriptDownloadRoute = createRoute(getScriptDownloadPath(env))
-  if (url.pathname.match(scriptDownloadRoute)) {
-    try {
-      return await handleDownloadScript(request)
-    } catch (e) {
-      return createErrorResponseForProCDN(e)
+  for (const route of routes) {
+    if (url.pathname.match(route.pathPattern)) {
+      return route.handler(request, env)
     }
-  }
-
-  const getResultRoute = createRoute(getGetResultPath(env))
-  if (url.pathname.match(getResultRoute)) {
-    try {
-      return await handleIngressAPI(request, env)
-    } catch (e) {
-      return createErrorResponseForIngress(request, e)
-    }
-  }
-
-  const healthRoute = createRoute(getHealthCheckPath(env))
-  if (url.pathname.match(healthRoute)) {
-    return handleHealthCheck(env)
-  }
-
-  const statusRoute = createRoute(getStatusPagePath(env))
-  if (url.pathname.match(statusRoute)) {
-    return handleStatusPage(env)
   }
 
   return new Response(JSON.stringify({ error: `unmatched path ${url.pathname}` }), { status: 404 })
+}
+
+export async function handleRequest(request: Request, env: WorkerEnv): Promise<Response> {
+  const routes = createRoutes(env)
+  return handleRequestWithRoutes(request, env, routes)
 }

--- a/src/handlers/handleStatusPage.ts
+++ b/src/handlers/handleStatusPage.ts
@@ -68,9 +68,9 @@ function addEnvVarsInformation(env: WorkerEnv): string {
 
 function buildBody(env: WorkerEnv): string {
   let body = `
-  <html lang="en-US">
+  <html lang='en-US'>
   <head>
-    <meta charset="utf-8"/>
+    <meta charset='utf-8'/>
   </head>
   <style>
     span {
@@ -96,7 +96,10 @@ function buildBody(env: WorkerEnv): string {
   return body
 }
 
-export function handleStatusPage(env: WorkerEnv): Response {
+export function handleStatusPage(request: Request, env: WorkerEnv): Response {
+  if (request.method !== 'GET') {
+    return new Response(null, { status: 405 })
+  }
   const headers = buildHeaders()
   const body = buildBody(env)
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -9,7 +9,7 @@ import { returnHttpResponse } from './returnHttpResponse'
 import { addProxyIntegrationHeaders } from './addProxyIntegrationHeaders'
 import { getEffectiveTLDPlusOne } from './getEffectiveTLDPlusOne'
 import { Cookie, createCookieStringFromObject, createCookieObjectFromHeaderValue, filterCookies } from './cookie'
-import { removeTrailingSlashes } from './routing'
+import { createRoute, addTrailingWildcard, removeTrailingSlashesAndMultiSlashes, replaceDot } from './routing'
 
 export {
   createCookieStringFromObject,
@@ -20,10 +20,13 @@ export {
   createErrorResponseForIngress,
   createErrorResponseForProCDN,
   addProxyIntegrationHeaders,
+  addTrailingWildcard,
+  removeTrailingSlashesAndMultiSlashes,
+  replaceDot,
   getEffectiveTLDPlusOne,
-  removeTrailingSlashes,
   returnHttpResponse,
   filterCookies,
   fetchCacheable,
+  createRoute,
   Cookie,
 }

--- a/src/utils/routing.ts
+++ b/src/utils/routing.ts
@@ -1,33 +1,19 @@
-export function removeTrailingSlashes(str: string): string {
-  return str.replace(/\/+$/, '')
+export function removeTrailingSlashesAndMultiSlashes(str: string): string {
+  return str.replace(/\/+$/, '').replace(/(?<=\/)\/+/, '')
 }
 
-function addTrailingWildcard(str: string): string {
+export function addTrailingWildcard(str: string): string {
   return str.replace(/(\/?)\*/g, '($1.*)?')
 }
 
-function removeTrailingSlashAndDoubleSlash(str: string): string {
-  return str.replace(/(\/$)|((?<=\/)\/)/, '')
-}
-
-function makeGreedy(str: string): string {
-  return str.replace(/(:(\w+)\+)/, '(?<$2>.*)')
-}
-
-function replaceNamedParams(str: string): string {
-  return str.replace(/:(\w+)(\?)?(\.)?/g, '$2(?<$1>[^/]+)$2$3')
-}
-
-function replaceDot(str: string): string {
+export function replaceDot(str: string): string {
   return str.replace(/\.(?=[\w(])/, '\\.')
 }
 
 export function createRoute(route: string): RegExp {
   let routeRegExp = route
-  routeRegExp = addTrailingWildcard(routeRegExp)
-  routeRegExp = removeTrailingSlashAndDoubleSlash(routeRegExp)
-  routeRegExp = makeGreedy(routeRegExp)
-  routeRegExp = replaceNamedParams(routeRegExp)
-  routeRegExp = replaceDot(routeRegExp)
+  // routeRegExp = addTrailingWildcard(routeRegExp) // Can be uncommented if wildcard (*) is needed
+  routeRegExp = removeTrailingSlashesAndMultiSlashes(routeRegExp)
+  // routeRegExp = replaceDot(routeRegExp) // Can be uncommented if dot (.) is needed
   return RegExp(`^${routeRegExp}/*$`)
 }

--- a/src/utils/routing.ts
+++ b/src/utils/routing.ts
@@ -1,3 +1,33 @@
 export function removeTrailingSlashes(str: string): string {
   return str.replace(/\/+$/, '')
 }
+
+function addTrailingWildcard(str: string): string {
+  return str.replace(/(\/?)\*/g, '($1.*)?')
+}
+
+function removeTrailingSlashAndDoubleSlash(str: string): string {
+  return str.replace(/(\/$)|((?<=\/)\/)/, '')
+}
+
+function makeGreedy(str: string): string {
+  return str.replace(/(:(\w+)\+)/, '(?<$2>.*)')
+}
+
+function replaceNamedParams(str: string): string {
+  return str.replace(/:(\w+)(\?)?(\.)?/g, '$2(?<$1>[^/]+)$2$3')
+}
+
+function replaceDot(str: string): string {
+  return str.replace(/\.(?=[\w(])/, '\\.')
+}
+
+export function createRoute(route: string): RegExp {
+  let routeRegExp = route
+  routeRegExp = addTrailingWildcard(routeRegExp)
+  routeRegExp = removeTrailingSlashAndDoubleSlash(routeRegExp)
+  routeRegExp = makeGreedy(routeRegExp)
+  routeRegExp = replaceNamedParams(routeRegExp)
+  routeRegExp = replaceDot(routeRegExp)
+  return RegExp(`^${routeRegExp}/*$`)
+}

--- a/test/handleRequest/handleRequestWithRoutes.test.ts
+++ b/test/handleRequest/handleRequestWithRoutes.test.ts
@@ -1,0 +1,164 @@
+import { handleRequestWithRoutes, Route } from '../../src/handler'
+import { getGetResultPath, getScriptDownloadPath, getStatusPagePath, WorkerEnv } from '../../src/env'
+import { createRoute } from '../../src/utils'
+
+const workerPath = 'worker'
+const agentScriptDownloadPath = 'agent'
+const getResultPath = 'get-result'
+const proxySecret = 'proxySecret'
+const env: WorkerEnv = {
+  WORKER_PATH: workerPath,
+  AGENT_SCRIPT_DOWNLOAD_PATH: agentScriptDownloadPath,
+  GET_RESULT_PATH: getResultPath,
+  PROXY_SECRET: proxySecret,
+}
+
+describe('download Pro Agent Script', () => {
+  let routes: Route[] = []
+  let mockAgentDownloadHandler: jest.Mock
+  beforeEach(() => {
+    mockAgentDownloadHandler = jest.fn()
+    routes = [
+      {
+        pathPattern: createRoute(getScriptDownloadPath(env)),
+        handler: mockAgentDownloadHandler,
+      },
+    ]
+  })
+  test('standard path', async () => {
+    const request = new Request(`https://example.com/${workerPath}/${agentScriptDownloadPath}`)
+    await handleRequestWithRoutes(request, env, routes)
+    expect(mockAgentDownloadHandler).toHaveBeenCalledTimes(1)
+  })
+  test('slash in the end', async () => {
+    const request = new Request(`https://example.com/${workerPath}/${agentScriptDownloadPath}/`)
+    await handleRequestWithRoutes(request, env, routes)
+    expect(mockAgentDownloadHandler).toHaveBeenCalledTimes(1)
+  })
+  test('with query params', async () => {
+    const request = new Request(`https://example.com/${workerPath}/${agentScriptDownloadPath}?key1=value1&key2=value2`)
+    await handleRequestWithRoutes(request, env, routes)
+    expect(mockAgentDownloadHandler).toHaveBeenCalledTimes(1)
+  })
+  test('HTTP Post method', async () => {
+    const request = new Request(`https://example.com/${workerPath}/${agentScriptDownloadPath}`, { method: 'POST' })
+    await handleRequestWithRoutes(request, env, routes)
+    expect(mockAgentDownloadHandler).toHaveBeenCalledTimes(1)
+  })
+  test('incorrect path', async () => {
+    const request = new Request(`https://example.com/${agentScriptDownloadPath}`)
+    await handleRequestWithRoutes(request, env, routes)
+    expect(mockAgentDownloadHandler).not.toHaveBeenCalled()
+  })
+})
+
+describe('get GetResult', () => {
+  let routes: Route[] = []
+  let mockIngressAPIHandler: jest.Mock
+  beforeEach(() => {
+    mockIngressAPIHandler = jest.fn()
+    routes = [
+      {
+        pathPattern: createRoute(getGetResultPath(env)),
+        handler: mockIngressAPIHandler,
+      },
+    ]
+  })
+  test('standard path', async () => {
+    const request = new Request(`https://example.com/${workerPath}/${getResultPath}`)
+    await handleRequestWithRoutes(request, env, routes)
+    expect(mockIngressAPIHandler).toHaveBeenCalledTimes(1)
+  })
+  test('slash in the end', async () => {
+    const request = new Request(`https://example.com/${workerPath}/${getResultPath}/`)
+    await handleRequestWithRoutes(request, env, routes)
+    expect(mockIngressAPIHandler).toHaveBeenCalledTimes(1)
+  })
+  test('with query params', async () => {
+    const request = new Request(`https://example.com/${workerPath}/${getResultPath}?key1=value1&key2=value2`)
+    await handleRequestWithRoutes(request, env, routes)
+    expect(mockIngressAPIHandler).toHaveBeenCalledTimes(1)
+  })
+  test('HTTP Post method', async () => {
+    const request = new Request(`https://example.com/${workerPath}/${getResultPath}`, { method: 'POST' })
+    await handleRequestWithRoutes(request, env, routes)
+    expect(mockIngressAPIHandler).toHaveBeenCalledTimes(1)
+  })
+  test('incorrect path', async () => {
+    const request = new Request(`https://example.com/${getResultPath}`)
+    await handleRequestWithRoutes(request, env, routes)
+    expect(mockIngressAPIHandler).not.toHaveBeenCalled()
+  })
+})
+
+describe('status page', () => {
+  let routes: Route[] = []
+  let mockStatusPageHandler: jest.Mock
+  beforeEach(() => {
+    mockStatusPageHandler = jest.fn()
+    routes = [
+      {
+        pathPattern: createRoute(getStatusPagePath(env)),
+        handler: mockStatusPageHandler,
+      },
+    ]
+  })
+  test('standard path', async () => {
+    const request = new Request(`https://example.com/${workerPath}/status`)
+    await handleRequestWithRoutes(request, env, routes)
+    expect(mockStatusPageHandler).toHaveBeenCalledTimes(1)
+  })
+  test('slash in the end', async () => {
+    const request = new Request(`https://example.com/${workerPath}/status/`)
+    await handleRequestWithRoutes(request, env, routes)
+    expect(mockStatusPageHandler).toHaveBeenCalledTimes(1)
+  })
+  test('with query params', async () => {
+    const request = new Request(`https://example.com/${workerPath}/status?key1=value1&key2=value2`)
+    await handleRequestWithRoutes(request, env, routes)
+    expect(mockStatusPageHandler).toHaveBeenCalledTimes(1)
+  })
+  test('HTTP Post method', async () => {
+    const request = new Request(`https://example.com/${workerPath}/status`, { method: 'POST' })
+    await handleRequestWithRoutes(request, env, routes)
+    expect(mockStatusPageHandler).toHaveBeenCalledTimes(1)
+  })
+  test('incorrect path', async () => {
+    const request = new Request(`https://example.com/status`)
+    await handleRequestWithRoutes(request, env, routes)
+    expect(mockStatusPageHandler).not.toHaveBeenCalled()
+  })
+})
+
+describe('no match paths', () => {
+  let routes: Route[] = []
+  let mockAgentDownloadHandler: jest.Mock
+  let mockIngressAPIHandler: jest.Mock
+  let mockStatusPageHandler: jest.Mock
+  beforeEach(() => {
+    mockAgentDownloadHandler = jest.fn()
+    mockIngressAPIHandler = jest.fn()
+    mockStatusPageHandler = jest.fn()
+    routes = [
+      {
+        pathPattern: createRoute(getScriptDownloadPath(env)),
+        handler: mockAgentDownloadHandler,
+      },
+      {
+        pathPattern: createRoute(getGetResultPath(env)),
+        handler: mockIngressAPIHandler,
+      },
+      {
+        pathPattern: createRoute(getStatusPagePath(env)),
+        handler: mockStatusPageHandler,
+      },
+    ]
+  })
+  test('no match', async () => {
+    const request = new Request(`https://example.com/${workerPath}/hello`)
+    await handleRequestWithRoutes(request, env, routes)
+    expect(mockAgentDownloadHandler).not.toHaveBeenCalled()
+    expect(mockIngressAPIHandler).not.toHaveBeenCalled()
+    expect(mockStatusPageHandler).not.toHaveBeenCalled()
+  })
+})

--- a/test/utils/routing.test.ts
+++ b/test/utils/routing.test.ts
@@ -1,28 +1,61 @@
-import { removeTrailingSlashes } from '../../src/utils'
+import { removeTrailingSlashesAndMultiSlashes, addTrailingWildcard, replaceDot } from '../../src/utils'
 
-describe('removeTrailingSlashes', () => {
+describe('removeTrailingSlashesAndMultiSlashes', () => {
   it('returns /path for /path', () => {
-    expect(removeTrailingSlashes('/path')).toBe('/path')
+    expect(removeTrailingSlashesAndMultiSlashes('/path')).toBe('/path')
   })
   it('returns /path for /path/', () => {
-    expect(removeTrailingSlashes('/path/')).toBe('/path')
+    expect(removeTrailingSlashesAndMultiSlashes('/path/')).toBe('/path')
   })
   it('returns /path for /path//////', () => {
-    expect(removeTrailingSlashes('/path//////')).toBe('/path')
+    expect(removeTrailingSlashesAndMultiSlashes('/path//////')).toBe('/path')
   })
   it('returns /path/path2 for /path/path2', () => {
-    expect(removeTrailingSlashes('/path/path2')).toBe('/path/path2')
+    expect(removeTrailingSlashesAndMultiSlashes('/path/path2')).toBe('/path/path2')
   })
   it('returns /path/path2 for /path/path2/', () => {
-    expect(removeTrailingSlashes('/path/path2/')).toBe('/path/path2')
+    expect(removeTrailingSlashesAndMultiSlashes('/path/path2/')).toBe('/path/path2')
   })
   it('returns /path/path2 for /path/path2//', () => {
-    expect(removeTrailingSlashes('/path/path2//')).toBe('/path/path2')
+    expect(removeTrailingSlashesAndMultiSlashes('/path/path2//')).toBe('/path/path2')
   })
-  it('returns /path//path2/path3 for /path//path2/path3/', () => {
-    expect(removeTrailingSlashes('/path//path2/path3/')).toBe('/path//path2/path3')
+  it('returns /path/path2/path3 for /path//path2/path3/', () => {
+    expect(removeTrailingSlashesAndMultiSlashes('/path//path2/path3/')).toBe('/path/path2/path3')
   })
-  it('returns empty string for empty string ', () => {
-    expect(removeTrailingSlashes('')).toBe('')
+  it('returns /path for ///path', () => {
+    expect(removeTrailingSlashesAndMultiSlashes('///path')).toBe('/path')
+  })
+  it('returns empty string for empty string', () => {
+    expect(removeTrailingSlashesAndMultiSlashes('')).toBe('')
+  })
+})
+
+describe('addTrailingWildcard', () => {
+  it('returns /a for /a', () => {
+    expect(addTrailingWildcard('/a')).toBe('/a')
+  })
+  it('returns /a(/.*)? for /a/*', () => {
+    expect(addTrailingWildcard('/a/*')).toBe('/a(/.*)?')
+  })
+  it('returns /a/b(.*)? for /a/b*', () => {
+    expect(addTrailingWildcard('/a/b*')).toBe('/a/b(.*)?')
+  })
+  it('returns empty string for empty string', () => {
+    expect(addTrailingWildcard('')).toBe('')
+  })
+})
+
+describe('replaceDot', () => {
+  it('returns /a for /a', () => {
+    expect(replaceDot('/a')).toBe('/a')
+  })
+  it('returns /a\\.b/c for /a.b/c', () => {
+    expect(replaceDot('/a.b/c')).toBe('/a\\.b/c')
+  })
+  it('returns /a/b. for /a/b.', () => {
+    expect(replaceDot('/a/b.')).toBe('/a/b.')
+  })
+  it('returns empty string for empty string', () => {
+    expect(replaceDot('')).toBe('')
   })
 })


### PR DESCRIPTION
This PR has several benefits:

- `Route` type and `handleRequestWithRoutes` function are introduced. Adding a new route is as simple as adding a new `Route` to the `createRoutes` function. 
- `Route` paths become `RegExp` instead of regular strings. This way, we eliminate string comparisons and the need for trimming slash `/` characters at the end of paths.
- Tests are added for `handleRequestWithRoutes`. These tests ensure that requests are handled by the correct handlers according to the environment variables.
- The routing library [itty-router](https://github.com/kwhitley/itty-router) is planned to be used at first, but then I realized that it doesn't add much value. I ended up using [some of the code](https://github.com/fingerprintjs/fingerprintjs-pro-cloudflare-worker/blob/feature/router/src/utils/routing.ts#L16) from that repository. As a result, the slashes `/` are now ignored in the environment variables when creating routes. Also, wildcard `*` and dot `.` characters can be enabled by uncommenting their implementations.
- Status page now returns HTTP 405 if the request method is not `GET`.