### PR TITLE
test: agent download and ingress api endpoints

### DIFF
--- a/.github/workflows/coverage-pr.yml
+++ b/.github/workflows/coverage-pr.yml
@@ -21,7 +21,7 @@ jobs:
         uses: fingerprintjs/action-coverage-report-md@v1
         id: coverage-md
         with:
-          srcBasePath: './src/utils'
+          srcBasePath: './src'
       - uses: marocchino/sticky-pull-request-comment@adca94abcaf73c10466a71cc83ae561fd66d1a56
         with:
           message: |

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,6 @@ module.exports = {
   testEnvironment: 'miniflare',
   testRegex: '/test/.+test.tsx?$',
   passWithNoTests: true,
-  collectCoverageFrom: ['./src/utils/**.ts'],
+  collectCoverageFrom: ['./src/**/*.ts'],
   coverageReporters: ['lcov', 'json-summary', ['text', { file: 'coverage.txt', path: './' }]],
 }

--- a/src/handlers/handleDownloadScript.ts
+++ b/src/handlers/handleDownloadScript.ts
@@ -10,14 +10,14 @@ function copySearchParams(oldURL: URL, newURL: URL): void {
   newURL.search = new URLSearchParams(oldURL.search).toString()
 }
 
-function createResponseWithMaxAge(oldResponse: Response, maxMaxAge: number): Response {
+function createResponseWithMaxAge(oldResponse: Response, maxMaxAge: number, maxSMaxAge: number): Response {
   const response = new Response(oldResponse.body, oldResponse)
   const oldCacheControlHeader = oldResponse.headers.get('cache-control')
   if (!oldCacheControlHeader) {
     return response
   }
 
-  const cacheControlHeader = getCacheControlHeaderWithMaxAgeIfLower(oldCacheControlHeader, maxMaxAge)
+  const cacheControlHeader = getCacheControlHeaderWithMaxAgeIfLower(oldCacheControlHeader, maxMaxAge, maxSMaxAge)
   response.headers.set('cache-control', cacheControlHeader)
   return response
 }
@@ -36,8 +36,9 @@ function makeDownloadScriptRequest(request: Request): Promise<Response> {
   const newRequest = new Request(newURL.toString(), new Request(request, { headers }))
   const workerCacheTtl = 5 * 60
   const maxMaxAge = 60 * 60
+  const maxSMaxAge = 60
 
-  return fetchCacheable(newRequest, workerCacheTtl).then((res) => createResponseWithMaxAge(res, maxMaxAge))
+  return fetchCacheable(newRequest, workerCacheTtl).then((res) => createResponseWithMaxAge(res, maxMaxAge, maxSMaxAge))
 }
 
 export async function handleDownloadScript(request: Request): Promise<Response> {

--- a/src/handlers/handleIngressAPI.ts
+++ b/src/handlers/handleIngressAPI.ts
@@ -16,7 +16,7 @@ declare global {
   }
 }
 
-function copySearchParams(oldURL: URL, newURL: URL) {
+function copySearchParams(oldURL: URL, newURL: URL): void {
   newURL.search = new URLSearchParams(oldURL.search).toString()
 }
 
@@ -46,27 +46,9 @@ function createResponseWithFirstPartyCookies(request: Request, response: Respons
   })
 }
 
-async function handleIngressAPIRaw(request: Request, url: URL, headers: Headers) {
-  if (request == null) {
-    throw new Error('request is null')
-  }
-
-  if (url == null) {
-    throw new Error('url is null')
-  }
-
-  console.log(`sending ingress api to ${url}...`)
-
-  const newRequest = new Request(url.toString(), new Request(request, { headers }))
-
-  const response = await fetch(newRequest)
-  return createResponseWithFirstPartyCookies(request, response)
-}
-
-async function makeIngressAPIRequest(request: Request, env: WorkerEnv) {
+function makeIngressAPIRequest(request: Request, env: WorkerEnv) {
   const oldURL = new URL(request.url)
-  const region = oldURL.searchParams.get('region') || 'us'
-  const endpoint = getVisitorIdEndpoint(region)
+  const endpoint = getVisitorIdEndpoint(oldURL.searchParams)
   const newURL = new URL(endpoint)
   copySearchParams(oldURL, newURL)
   addTrafficMonitoringSearchParamsForVisitorIdRequest(newURL)
@@ -75,7 +57,9 @@ async function makeIngressAPIRequest(request: Request, env: WorkerEnv) {
   addProxyIntegrationHeaders(headers, env)
   headers = filterCookies(headers, (key) => key === '_iidt')
 
-  return handleIngressAPIRaw(request, newURL, headers)
+  console.log(`sending ingress api to ${newURL}...`)
+  const newRequest = new Request(newURL.toString(), new Request(request, { headers }))
+  return fetch(newRequest).then((response) => createResponseWithFirstPartyCookies(request, response))
 }
 
 export async function handleIngressAPI(request: Request, env: WorkerEnv) {

--- a/src/utils/createErrorResponse.ts
+++ b/src/utils/createErrorResponse.ts
@@ -59,11 +59,12 @@ export function createErrorResponseForIngress(request: Request, error: string | 
   const responseHeaders: HeadersInit = {
     'Access-Control-Allow-Origin': requestOrigin,
     'Access-Control-Allow-Credentials': 'true',
+    'content-type': 'application/json',
   }
   return new Response(JSON.stringify(responseBody), { status: 500, headers: responseHeaders })
 }
 
 export function createErrorResponseForProCDN(error: string | Error | unknown): Response {
   const responseBody = { error: errorToString(error) }
-  return new Response(JSON.stringify(responseBody), { status: 500 })
+  return new Response(JSON.stringify(responseBody), { status: 500, headers: { 'content-type': 'application/json' } })
 }

--- a/src/utils/getCacheControlHeaderWithMaxAgeIfLower.ts
+++ b/src/utils/getCacheControlHeaderWithMaxAgeIfLower.ts
@@ -11,11 +11,15 @@ function setDirective(directives: string[], directive: 'max-age' | 's-maxage', m
   }
 }
 
-export function getCacheControlHeaderWithMaxAgeIfLower(cacheControlHeaderValue: string, maxMaxAge: number): string {
+export function getCacheControlHeaderWithMaxAgeIfLower(
+  cacheControlHeaderValue: string,
+  maxMaxAge: number,
+  maxSMaxAge: number,
+): string {
   const cacheControlDirectives = cacheControlHeaderValue.split(', ')
 
   setDirective(cacheControlDirectives, 'max-age', maxMaxAge)
-  setDirective(cacheControlDirectives, 's-maxage', maxMaxAge)
+  setDirective(cacheControlDirectives, 's-maxage', maxSMaxAge)
 
   return cacheControlDirectives.join(', ')
 }

--- a/src/utils/proxyEndpoint.ts
+++ b/src/utils/proxyEndpoint.ts
@@ -12,7 +12,8 @@ export function getAgentScriptEndpoint(searchParams: URLSearchParams): string {
   return `${base}${lv}`
 }
 
-export function getVisitorIdEndpoint(region: string) {
+export function getVisitorIdEndpoint(searchParams: URLSearchParams): string {
+  const region = searchParams.get('region') || 'us'
   const prefix = region === DEFAULT_REGION ? '' : `${region}.`
   return `https://${prefix}api.fpjs.io`
 }

--- a/test/endpoints/__snapshots__/status.test.ts.snap
+++ b/test/endpoints/__snapshots__/status.test.ts.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`status renders the status page 1`] = `
+"
+  <html lang='en-US'>
+  <head>
+    <meta charset='utf-8'/>
+  </head>
+  <style>
+    span {
+      display: block;
+      padding-top: 1em;
+      padding-bottom: 1em;
+      text-align: center;
+    }
+  </style>
+  <body>
+  <span>Your worker is deployed</span>
+  <span>
+  Worker version: __current_worker_version__
+  </span>
+  
+    <span>
+    All environment variables are set
+    </span>
+    
+  <span>
+  Please reach out our support via <a href='mailto:support@fingerprint.com'>support@fingerprint.com</a> if you have any issues
+  </span>
+    
+  </body>
+  </html>
+  "
+`;

--- a/test/endpoints/agentDownload.test.ts
+++ b/test/endpoints/agentDownload.test.ts
@@ -271,7 +271,7 @@ describe('agent download request cache durations', () => {
   })
 })
 
-describe('agent download request and response', () => {
+describe('agent download response', () => {
   let fetchSpy: jest.MockInstance<Promise<Response>, any>
 
   beforeAll(() => {

--- a/test/endpoints/agentDownload.test.ts
+++ b/test/endpoints/agentDownload.test.ts
@@ -1,0 +1,131 @@
+import worker from '../../src/index'
+import { WorkerEnv } from '../../src/env'
+
+const workerEnv: WorkerEnv = {
+  WORKER_PATH: 'worker_path',
+  PROXY_SECRET: 'proxy_secret',
+  GET_RESULT_PATH: 'get_result',
+  AGENT_SCRIPT_DOWNLOAD_PATH: 'agent_download',
+}
+
+describe('agent download request and response', () => {
+  const fetchSpy = jest.spyOn(globalThis, 'fetch')
+
+  afterAll(() => {
+    fetchSpy.mockRestore()
+  })
+
+  test('url search, cf cache and response headers', async () => {
+    fetchSpy.mockImplementation(async (input, init) => {
+      const req = new Request(input, init)
+      const headers: HeadersInit = {
+        'cache-control': 'max-age=72000',
+        'strict-transport-security': 'max-age=63072000; includeSubDomains; preload',
+      }
+      const bodyObject = {
+        url: req.url,
+        cf: (init as RequestInit).cf,
+      }
+      return new Response(JSON.stringify(bodyObject), { headers })
+    })
+
+    const headers = new Headers({
+      cookie:
+        '_iidt=GlMQaHMfzYvomxCuA7Uymy7ArmjH04jPkT+enN7j/Xk8tJG+UYcQV+Qw60Ry4huw9bmDoO/smyjQp5vLCuSf8t4Jow==; auth_token=123456',
+    })
+    const req = new Request('https://example.com/worker_path/agent_download?apiKey=someApiKey&someKey=someValue', {
+      headers,
+    })
+    const response = await worker.fetch(req, workerEnv)
+    expect(response.headers.get('cache-control')).toBe('max-age=3600, s-maxage=3600')
+    expect(response.headers.get('strict-transport-security')).toBe(null)
+    expect(response.headers.get('cookie')).toBe(null)
+    const responseBody = (await response.json()) as any
+    const url = new URL(responseBody.url)
+    expect(url.origin).toBe('https://fpcdn.io')
+    expect(url.pathname).toBe('/v3/someApiKey')
+    expect(url.search).toBe(
+      '?apiKey=someApiKey&someKey=someValue&ii=fingerprintjs-pro-cloudflare%2F__current_worker_version__%2Fprocdn',
+    )
+    // Note: toStrictEqual does not work for some reason, using double toMatchObject instead
+    expect(responseBody.cf).toMatchObject({ cacheTtl: 300 })
+    expect({ cacheTtl: 300 }).toMatchObject(responseBody.cf)
+  })
+  test("response body and content-type don't change", async () => {
+    const agentScript =
+      '/** FingerprintJS Pro - Copyright (c) FingerprintJS, Inc, 2022 (https://fingerprint.com) /** function hi() { console.log("hello world!!") }'
+    fetchSpy.mockImplementation(async () => {
+      const headers: HeadersInit = {
+        'content-type': 'text/javascript; charset=utf-8',
+      }
+      return new Response(agentScript, { headers })
+    })
+    const req = new Request('https://example.com/worker_path/agent_download')
+    const response = await worker.fetch(req, workerEnv)
+    expect(response.headers.get('content-type')).toBe('text/javascript; charset=utf-8')
+    expect(await response.text()).toBe(agentScript)
+  })
+  test('endpoint url when version exists', async () => {
+    fetchSpy.mockImplementation(async (input, init) => {
+      const req = new Request(input, init)
+      const bodyObject = {
+        url: req.url,
+      }
+      return new Response(JSON.stringify(bodyObject))
+    })
+    const req = new Request(
+      'https://example.com/worker_path/agent_download?apiKey=someApiKey&version=5&someKey=someValue',
+    )
+    const response = await worker.fetch(req, workerEnv)
+    const responseBody = (await response.json()) as any
+    const url = new URL(responseBody.url)
+    expect(url.origin).toBe('https://fpcdn.io')
+    expect(url.pathname).toBe('/v5/someApiKey')
+    expect(url.search).toBe(
+      '?apiKey=someApiKey&version=5&someKey=someValue&ii=fingerprintjs-pro-cloudflare%2F__current_worker_version__%2Fprocdn',
+    )
+  })
+  test('endpoint url when version and loaderVersion exists', async () => {
+    fetchSpy.mockImplementation(async (input, init) => {
+      const req = new Request(input, init)
+      const bodyObject = {
+        url: req.url,
+      }
+      return new Response(JSON.stringify(bodyObject))
+    })
+    const req = new Request(
+      'https://example.com/worker_path/agent_download?apiKey=someApiKey&version=5&loaderVersion=1.2.3',
+    )
+    const response = await worker.fetch(req, workerEnv)
+    const responseBody = (await response.json()) as any
+    const url = new URL(responseBody.url)
+    expect(url.origin).toBe('https://fpcdn.io')
+    expect(url.pathname).toBe('/v5/someApiKey/loader_v1.2.3.js')
+    expect(url.search).toBe(
+      '?apiKey=someApiKey&version=5&loaderVersion=1.2.3&ii=fingerprintjs-pro-cloudflare%2F__current_worker_version__%2Fprocdn',
+    )
+  })
+  test('failure response', async () => {
+    fetchSpy.mockImplementation(async () => {
+      return new Response('some error', { status: 500, headers: { 'content-type': 'text/plain; charset=UTF-8' } })
+    })
+    const req = new Request('https://example.com/worker_path/agent_download')
+    const response = await worker.fetch(req, workerEnv)
+    expect(response.headers.get('content-type')).toBe('text/plain; charset=UTF-8')
+    expect(response.status).toBe(500)
+    expect(await response.text()).toBe('some error')
+  })
+  test('error response', async () => {
+    fetchSpy.mockImplementation(async () => {
+      throw new Error('some error')
+    })
+    const req = new Request('https://example.com/worker_path/agent_download')
+    const response = await worker.fetch(req, workerEnv)
+    expect(response.headers.get('content-type')).toBe('application/json')
+    expect(response.status).toBe(500)
+    const responseBody = await response.json()
+    // Note: toStrictEqual does not work for some reason, using double toMatchObject instead
+    expect(responseBody).toMatchObject({ error: 'some error' })
+    expect({ error: 'some error' }).toMatchObject(responseBody as any)
+  })
+})

--- a/test/endpoints/getResult.test.ts
+++ b/test/endpoints/getResult.test.ts
@@ -1,0 +1,196 @@
+import { WorkerEnv } from '../../src/env'
+import worker from '../../src'
+import { FPJSResponse } from '../../src/utils/createErrorResponse'
+
+const workerEnv: WorkerEnv = {
+  WORKER_PATH: 'worker_path',
+  PROXY_SECRET: 'proxy_secret',
+  GET_RESULT_PATH: 'get_result',
+  AGENT_SCRIPT_DOWNLOAD_PATH: 'agent_download',
+}
+
+describe('ingress API request and response', () => {
+  const fetchSpy = jest.spyOn(globalThis, 'fetch')
+
+  afterAll(() => {
+    fetchSpy.mockRestore()
+  })
+
+  test('url search, cookie filtering, proxy secret and response headers', async () => {
+    fetchSpy.mockImplementation(async (input, init) => {
+      const req = new Request(input, init)
+      const headers: HeadersInit = {
+        'strict-transport-security': 'max-age=63072000',
+        'set-cookie':
+          '_iidt=GlMQaHMfzYvomxCuA7Uymy7ArmjH04jPkT+enN7j/Xk8tJG+UYcQV+Qw60Ry4huw9bmDoO/smyjQp5vLCuSf8t4Jow==; Path=/; Domain=fpjs.io; Expires=Fri, 19 Jan 2024 08:54:36 GMT; HttpOnly; Secure; SameSite=None',
+      }
+      const bodyObject = {
+        url: req.url,
+        reqHeaders: Object.fromEntries(req.headers),
+      }
+      return new Response(JSON.stringify(bodyObject), { headers })
+    })
+
+    const headers = new Headers({
+      cookie:
+        '_iidt=GlMQaHMfzYvomxCuA7Uymy7ArmjH04jPkT+enN7j/Xk8tJG+UYcQV+Qw60Ry4huw9bmDoO/smyjQp5vLCuSf8t4Jow==; auth_token=123456',
+    })
+    const req = new Request(
+      'https://example.com/worker_path/get_result?ii=fingerprintjs-pro-cloudflare%2Fv1.0.0%2Fprocdn&a=b',
+      { headers },
+    )
+    const response = await worker.fetch(req, workerEnv)
+    expect(response.headers.get('strict-transport-security')).toBe(null)
+    expect(response.headers.get('set-cookie')).toBe(
+      '_iidt=GlMQaHMfzYvomxCuA7Uymy7ArmjH04jPkT+enN7j/Xk8tJG+UYcQV+Qw60Ry4huw9bmDoO/smyjQp5vLCuSf8t4Jow==; Path=/; Domain=example.com; Expires=Fri, 19 Jan 2024 08:54:36 GMT; HttpOnly; Secure; SameSite=None',
+    )
+    const responseBody = (await response.json()) as any
+    const url = new URL(responseBody.url)
+    expect(url.origin).toBe('https://api.fpjs.io')
+    expect(url.search).toBe(
+      '?ii=fingerprintjs-pro-cloudflare%2Fv1.0.0%2Fprocdn&a=b&ii=fingerprintjs-pro-cloudflare%2F__current_worker_version__%2Fingress',
+    )
+    const reqHeaders = new Headers(responseBody.reqHeaders)
+    expect(reqHeaders.get('cookie')).toBe(
+      '_iidt=GlMQaHMfzYvomxCuA7Uymy7ArmjH04jPkT+enN7j/Xk8tJG+UYcQV+Qw60Ry4huw9bmDoO/smyjQp5vLCuSf8t4Jow==',
+    )
+    expect(reqHeaders.get('FPJS-Proxy-Secret')).toBe('proxy_secret')
+    // expect(reqHeaders.get('FPJS-Proxy-Client-IP')).toBe('127.0.0.1') todo test for client IP
+  })
+  test('when no proxy secret', async () => {
+    fetchSpy.mockImplementation(async (input, init) => {
+      const req = new Request(input, init)
+      const bodyObject = {
+        reqHeaders: Object.fromEntries(req.headers),
+      }
+      return new Response(JSON.stringify(bodyObject))
+    })
+
+    const headers = new Headers({
+      cookie:
+        '_iidt=GlMQaHMfzYvomxCuA7Uymy7ArmjH04jPkT+enN7j/Xk8tJG+UYcQV+Qw60Ry4huw9bmDoO/smyjQp5vLCuSf8t4Jow==; auth_token=123456',
+    })
+    const req = new Request(
+      'https://example.com/worker_path/get_result?ii=fingerprintjs-pro-cloudflare%2Fv1.0.0%2Fprocdn&a=b',
+      { headers },
+    )
+    const workerEnv: WorkerEnv = {
+      WORKER_PATH: 'worker_path',
+      PROXY_SECRET: null,
+      GET_RESULT_PATH: 'get_result',
+      AGENT_SCRIPT_DOWNLOAD_PATH: 'agent_download',
+    }
+    const response = await worker.fetch(req, workerEnv)
+    const responseBody = (await response.json()) as any
+    const reqHeaders = new Headers(responseBody.reqHeaders)
+    expect(reqHeaders.get('FPJS-Proxy-Secret')).toBe(null)
+    expect(reqHeaders.get('FPJS-Proxy-Client-IP')).toBe(null)
+  })
+  // test('proxy secret client IP', async () => {
+  //   fetchSpy.mockImplementation(async (input, init) => {
+  //     const req = new Request(input, init)
+  //     const bodyObject = {
+  //       reqHeaders: Object.fromEntries(req.headers),
+  //     }
+  //     return new Response(JSON.stringify(bodyObject))
+  //   })
+  //   const mf = new Miniflare({
+  //     packagePath: true,
+  //     wranglerConfigPath: true,
+  //     async metaProvider() {
+  //       return {
+  //         realIp: '100.101.102.103',
+  //       }
+  //     },
+  //   })
+  //   const response = await mf.dispatchFetch('http://localhost:8787')
+  //   const responseBody = (await response.json()) as any
+  //   const reqHeaders = new Headers(responseBody.reqHeaders)
+  //   expect(reqHeaders.get('FPJS-Proxy-Client-IP')).toBe('100.101.102.103')
+  // })
+  test('eu region', async () => {
+    fetchSpy.mockImplementation(async (input, init) => {
+      const req = new Request(input, init)
+      const bodyObject = {
+        url: req.url,
+      }
+      return new Response(JSON.stringify(bodyObject))
+    })
+    const req = new Request(
+      'https://example.com/worker_path/get_result?ii=fingerprintjs-pro-cloudflare%2Fv1.0.0%2Fprocdn&a=b&region=eu',
+      {
+        headers: {
+          cookie:
+            '_iidt=GlMQaHMfzYvomxCuA7Uymy7ArmjH04jPkT+enN7j/Xk8tJG+UYcQV+Qw60Ry4huw9bmDoO/smyjQp5vLCuSf8t4Jow==; auth_token=123456',
+        },
+      },
+    )
+    const response = await worker.fetch(req, workerEnv)
+    const responseBody = (await response.json()) as any
+    const url = new URL(responseBody.url)
+    expect(url.origin).toBe('https://eu.api.fpjs.io')
+  })
+  test('ap region', async () => {
+    fetchSpy.mockImplementation(async (input, init) => {
+      const req = new Request(input, init)
+      const bodyObject = {
+        url: req.url,
+      }
+      return new Response(JSON.stringify(bodyObject))
+    })
+    const req = new Request(
+      'https://example.com/worker_path/get_result?ii=fingerprintjs-pro-cloudflare%2Fv1.0.0%2Fprocdn&a=b&region=ap',
+      {
+        headers: {
+          cookie:
+            '_iidt=GlMQaHMfzYvomxCuA7Uymy7ArmjH04jPkT+enN7j/Xk8tJG+UYcQV+Qw60Ry4huw9bmDoO/smyjQp5vLCuSf8t4Jow==; auth_token=123456',
+        },
+      },
+    )
+    const response = await worker.fetch(req, workerEnv)
+    const responseBody = (await response.json()) as any
+    const url = new URL(responseBody.url)
+    expect(url.origin).toBe('https://ap.api.fpjs.io')
+  })
+  test('failure response', async () => {
+    fetchSpy.mockImplementation(async () => {
+      return new Response('some error', { status: 500, headers: { 'content-type': 'text/plain; charset=UTF-8' } })
+    })
+    const req = new Request('https://example.com/worker_path/get_result')
+    const response = await worker.fetch(req, workerEnv)
+    expect(response.headers.get('content-type')).toBe('text/plain; charset=UTF-8')
+    expect(response.status).toBe(500)
+    expect(await response.text()).toBe('some error')
+  })
+  test('error response', async () => {
+    fetchSpy.mockImplementation(async () => {
+      throw new Error('some error')
+    })
+    const req = new Request('https://example.com/worker_path/get_result', {
+      headers: { origin: 'https://example.com' },
+    })
+    const response = await worker.fetch(req, workerEnv)
+    expect(response.headers.get('content-type')).toBe('application/json')
+    expect(response.status).toBe(500)
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://example.com')
+    expect(response.headers.get('Access-Control-Allow-Credentials')).toBe('true')
+    const responseBody = (await response.json()) as unknown as FPJSResponse
+    const expectedResponseBody: Omit<FPJSResponse, 'requestId'> = {
+      v: '2',
+      error: {
+        code: 'IntegrationFailed',
+        message: 'An error occurred with Cloudflare worker. Reason: some error',
+      },
+      products: {},
+    }
+    const requestId = responseBody.requestId
+    expect(requestId).toMatch(/^\d{13}\.[a-zA-Z\d]{6}$/)
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const modifiedResponseBody: Omit<FPJSResponse, 'requestId'> = (({ requestId, ...rest }) => ({ ...rest }))(
+      responseBody,
+    )
+    // Note: toStrictEqual does not work for some reason, using double toMatchObject instead
+    expect(modifiedResponseBody).toMatchObject(expectedResponseBody)
+    expect(expectedResponseBody).toMatchObject(modifiedResponseBody)
+  })
+})

--- a/test/endpoints/getResult.test.ts
+++ b/test/endpoints/getResult.test.ts
@@ -297,7 +297,21 @@ describe('ingress API response headers', () => {
     fetchSpy.mockRestore()
   })
 
-  test('cookies are the same except domain is set to be first party, the domain is derived from the req url', async () => {
+  test('cookies are the same except domain', async () => {
+    fetchSpy.mockImplementation(async () => {
+      const headers = new Headers({
+        'set-cookie':
+          '_iidt=GlMQaHMfzYvomxCuA7Uymy7ArmjH04jPkT+enN7j/Xk8tJG+UYcQV+Qw60Ry4huw9bmDoO/smyjQp5vLCuSf8t4Jow==; Path=/; Domain=fpjs.io; Expires=Fri, 19 Jan 2024 08:54:36 GMT; HttpOnly; Secure; SameSite=None, anotherCookie=anotherValue; Domain=fpjs.io;',
+      })
+      return new Response('', { headers })
+    })
+    const req = new Request('https://example.com/worker_path/get_result')
+    const response = await worker.fetch(req, workerEnv)
+    expect(response.headers.get('set-cookie')).toBe(
+      '_iidt=GlMQaHMfzYvomxCuA7Uymy7ArmjH04jPkT+enN7j/Xk8tJG+UYcQV+Qw60Ry4huw9bmDoO/smyjQp5vLCuSf8t4Jow==; Path=/; Domain=example.com; Expires=Fri, 19 Jan 2024 08:54:36 GMT; HttpOnly; Secure; SameSite=None, anotherCookie=anotherValue; Domain=example.com',
+    )
+  })
+  test('cookies are first party for the req url whose TLD is a regular TLD, the domain is derived from the req url (not origin header)', async () => {
     fetchSpy.mockImplementation(async () => {
       const headers = new Headers({
         origin: 'https://some-other.com',
@@ -310,6 +324,36 @@ describe('ingress API response headers', () => {
     const response = await worker.fetch(req, workerEnv)
     expect(response.headers.get('set-cookie')).toBe(
       '_iidt=GlMQaHMfzYvomxCuA7Uymy7ArmjH04jPkT+enN7j/Xk8tJG+UYcQV+Qw60Ry4huw9bmDoO/smyjQp5vLCuSf8t4Jow==; Path=/; Domain=example.com; Expires=Fri, 19 Jan 2024 08:54:36 GMT; HttpOnly; Secure; SameSite=None, anotherCookie=anotherValue; Domain=example.com',
+    )
+  })
+  test('cookies are first party for the req url whose TLD has wildcard, the domain is derived from the req url (not origin header)', async () => {
+    fetchSpy.mockImplementation(async () => {
+      const headers = new Headers({
+        origin: 'https://some-other.com',
+        'set-cookie':
+          '_iidt=GlMQaHMfzYvomxCuA7Uymy7ArmjH04jPkT+enN7j/Xk8tJG+UYcQV+Qw60Ry4huw9bmDoO/smyjQp5vLCuSf8t4Jow==; Path=/; Domain=fpjs.io; Expires=Fri, 19 Jan 2024 08:54:36 GMT; HttpOnly; Secure; SameSite=None, anotherCookie=anotherValue; Domain=fpjs.io;',
+      })
+      return new Response('', { headers })
+    })
+    const req = new Request('https://sub2.sub1.some.alces.network/worker_path/get_result')
+    const response = await worker.fetch(req, workerEnv)
+    expect(response.headers.get('set-cookie')).toBe(
+      '_iidt=GlMQaHMfzYvomxCuA7Uymy7ArmjH04jPkT+enN7j/Xk8tJG+UYcQV+Qw60Ry4huw9bmDoO/smyjQp5vLCuSf8t4Jow==; Path=/; Domain=sub1.some.alces.network; Expires=Fri, 19 Jan 2024 08:54:36 GMT; HttpOnly; Secure; SameSite=None, anotherCookie=anotherValue; Domain=sub1.some.alces.network',
+    )
+  })
+  test('cookies are first party for the req url whose TLD has exception, the domain is derived from the req url (not origin header)', async () => {
+    fetchSpy.mockImplementation(async () => {
+      const headers = new Headers({
+        origin: 'https://some-other.com',
+        'set-cookie':
+          '_iidt=GlMQaHMfzYvomxCuA7Uymy7ArmjH04jPkT+enN7j/Xk8tJG+UYcQV+Qw60Ry4huw9bmDoO/smyjQp5vLCuSf8t4Jow==; Path=/; Domain=fpjs.io; Expires=Fri, 19 Jan 2024 08:54:36 GMT; HttpOnly; Secure; SameSite=None, anotherCookie=anotherValue; Domain=fpjs.io;',
+      })
+      return new Response('', { headers })
+    })
+    const req = new Request('https://city.kawasaki.jp/worker_path/get_result')
+    const response = await worker.fetch(req, workerEnv)
+    expect(response.headers.get('set-cookie')).toBe(
+      '_iidt=GlMQaHMfzYvomxCuA7Uymy7ArmjH04jPkT+enN7j/Xk8tJG+UYcQV+Qw60Ry4huw9bmDoO/smyjQp5vLCuSf8t4Jow==; Path=/; Domain=city.kawasaki.jp; Expires=Fri, 19 Jan 2024 08:54:36 GMT; HttpOnly; Secure; SameSite=None, anotherCookie=anotherValue; Domain=city.kawasaki.jp',
     )
   })
   test('response headers are the same (except HSTS and set-cookie)', async () => {

--- a/test/endpoints/getResult.test.ts
+++ b/test/endpoints/getResult.test.ts
@@ -9,172 +9,401 @@ const workerEnv: WorkerEnv = {
   AGENT_SCRIPT_DOWNLOAD_PATH: 'agent_download',
 }
 
-describe('ingress API request and response', () => {
-  const fetchSpy = jest.spyOn(globalThis, 'fetch')
+describe('ingress API request proxy URL', () => {
+  let fetchSpy: jest.MockInstance<Promise<Response>, any>
+  let reqURL: URL
+  let receivedReqURL = ''
+
+  beforeAll(() => {
+    fetchSpy = jest.spyOn(globalThis, 'fetch')
+    fetchSpy.mockImplementation(async (input, init) => {
+      const req = new Request(input, init)
+      receivedReqURL = req.url
+      return new Response()
+    })
+  })
+
+  beforeEach(() => {
+    reqURL = new URL('https://example.com/worker_path/get_result')
+
+    receivedReqURL = ''
+  })
 
   afterAll(() => {
     fetchSpy.mockRestore()
   })
 
-  test('url search, cookie filtering, proxy secret and response headers', async () => {
-    fetchSpy.mockImplementation(async (input, init) => {
-      const req = new Request(input, init)
-      const headers: HeadersInit = {
-        'strict-transport-security': 'max-age=63072000',
-        'set-cookie':
-          '_iidt=GlMQaHMfzYvomxCuA7Uymy7ArmjH04jPkT+enN7j/Xk8tJG+UYcQV+Qw60Ry4huw9bmDoO/smyjQp5vLCuSf8t4Jow==; Path=/; Domain=fpjs.io; Expires=Fri, 19 Jan 2024 08:54:36 GMT; HttpOnly; Secure; SameSite=None',
-      }
-      const bodyObject = {
-        url: req.url,
-        reqHeaders: Object.fromEntries(req.headers),
-      }
-      return new Response(JSON.stringify(bodyObject), { headers })
-    })
-
-    const headers = new Headers({
-      cookie:
-        '_iidt=GlMQaHMfzYvomxCuA7Uymy7ArmjH04jPkT+enN7j/Xk8tJG+UYcQV+Qw60Ry4huw9bmDoO/smyjQp5vLCuSf8t4Jow==; auth_token=123456',
-    })
-    const req = new Request(
-      'https://example.com/worker_path/get_result?ii=fingerprintjs-pro-cloudflare%2Fv1.0.0%2Fprocdn&a=b',
-      { headers },
-    )
-    const response = await worker.fetch(req, workerEnv)
-    expect(response.headers.get('strict-transport-security')).toBe(null)
-    expect(response.headers.get('set-cookie')).toBe(
-      '_iidt=GlMQaHMfzYvomxCuA7Uymy7ArmjH04jPkT+enN7j/Xk8tJG+UYcQV+Qw60Ry4huw9bmDoO/smyjQp5vLCuSf8t4Jow==; Path=/; Domain=example.com; Expires=Fri, 19 Jan 2024 08:54:36 GMT; HttpOnly; Secure; SameSite=None',
-    )
-    const responseBody = (await response.json()) as any
-    const url = new URL(responseBody.url)
-    expect(url.origin).toBe('https://api.fpjs.io')
-    expect(url.search).toBe(
-      '?ii=fingerprintjs-pro-cloudflare%2Fv1.0.0%2Fprocdn&a=b&ii=fingerprintjs-pro-cloudflare%2F__current_worker_version__%2Fingress',
-    )
-    const reqHeaders = new Headers(responseBody.reqHeaders)
-    expect(reqHeaders.get('cookie')).toBe(
-      '_iidt=GlMQaHMfzYvomxCuA7Uymy7ArmjH04jPkT+enN7j/Xk8tJG+UYcQV+Qw60Ry4huw9bmDoO/smyjQp5vLCuSf8t4Jow==',
-    )
-    expect(reqHeaders.get('FPJS-Proxy-Secret')).toBe('proxy_secret')
-    // expect(reqHeaders.get('FPJS-Proxy-Client-IP')).toBe('127.0.0.1') todo test for client IP
+  test('no region', async () => {
+    const req = new Request(reqURL.toString(), { method: 'POST' })
+    await worker.fetch(req, workerEnv)
+    const receivedURL = new URL(receivedReqURL)
+    expect(receivedURL.origin).toBe('https://api.fpjs.io')
   })
-  test('when no proxy secret', async () => {
+
+  test('us region', async () => {
+    reqURL.searchParams.append('region', 'us')
+    const req = new Request(reqURL.toString(), { method: 'POST' })
+    await worker.fetch(req, workerEnv)
+    const receivedURL = new URL(receivedReqURL)
+    expect(receivedURL.origin).toBe('https://api.fpjs.io')
+  })
+
+  test('eu region', async () => {
+    reqURL.searchParams.append('region', 'eu')
+    const req = new Request(reqURL.toString(), { method: 'POST' })
+    await worker.fetch(req, workerEnv)
+    const receivedURL = new URL(receivedReqURL)
+    expect(receivedURL.origin).toBe('https://eu.api.fpjs.io')
+  })
+
+  test('ap region', async () => {
+    reqURL.searchParams.append('region', 'ap')
+    const req = new Request(reqURL.toString(), { method: 'POST' })
+    await worker.fetch(req, workerEnv)
+    const receivedURL = new URL(receivedReqURL)
+    expect(receivedURL.origin).toBe('https://ap.api.fpjs.io')
+  })
+})
+
+describe('ingress API request query parameters', () => {
+  let fetchSpy: jest.MockInstance<Promise<Response>, any>
+  let reqURL: URL
+  let receivedReqURL = ''
+
+  beforeAll(() => {
+    fetchSpy = jest.spyOn(globalThis, 'fetch')
     fetchSpy.mockImplementation(async (input, init) => {
       const req = new Request(input, init)
-      const bodyObject = {
-        reqHeaders: Object.fromEntries(req.headers),
-      }
-      return new Response(JSON.stringify(bodyObject))
-    })
+      receivedReqURL = req.url
 
-    const headers = new Headers({
-      cookie:
-        '_iidt=GlMQaHMfzYvomxCuA7Uymy7ArmjH04jPkT+enN7j/Xk8tJG+UYcQV+Qw60Ry4huw9bmDoO/smyjQp5vLCuSf8t4Jow==; auth_token=123456',
+      return new Response('')
     })
-    const req = new Request(
-      'https://example.com/worker_path/get_result?ii=fingerprintjs-pro-cloudflare%2Fv1.0.0%2Fprocdn&a=b',
-      { headers },
+  })
+
+  beforeEach(() => {
+    reqURL = new URL('https://example.com/worker_path/get_result')
+    reqURL.searchParams.append('someKey', 'someValue')
+
+    receivedReqURL = ''
+  })
+
+  afterAll(() => {
+    fetchSpy.mockRestore()
+  })
+
+  test('traffic monitoring when no ii parameter before', async () => {
+    const req = new Request(reqURL.toString(), { method: 'POST' })
+    await worker.fetch(req, workerEnv)
+    const url = new URL(receivedReqURL)
+    const iiValues = url.searchParams.getAll('ii')
+    expect(iiValues.length).toBe(1)
+    expect(iiValues[0]).toBe('fingerprintjs-pro-cloudflare/__current_worker_version__/ingress')
+  })
+  test('traffic monitoring when there is ii parameter before', async () => {
+    reqURL.searchParams.append('ii', 'fingerprintjs-pro-react/v1.2.3')
+    const req = new Request(reqURL.toString(), { method: 'POST' })
+    await worker.fetch(req, workerEnv)
+    const url = new URL(receivedReqURL)
+    const iiValues = url.searchParams.getAll('ii')
+    expect(iiValues.length).toBe(2)
+    expect(iiValues[0]).toBe('fingerprintjs-pro-react/v1.2.3')
+    expect(iiValues[1]).toBe('fingerprintjs-pro-cloudflare/__current_worker_version__/ingress')
+  })
+  test('whole query string when no ii parameter before', async () => {
+    const req = new Request(reqURL.toString(), { method: 'POST' })
+    await worker.fetch(req, workerEnv)
+    const url = new URL(receivedReqURL)
+    expect(url.search).toBe(
+      '?someKey=someValue' + '&ii=fingerprintjs-pro-cloudflare%2F__current_worker_version__%2Fingress',
     )
+  })
+  test('whole query string when there is ii parameter before', async () => {
+    reqURL.searchParams.append('ii', 'fingerprintjs-pro-react/v1.2.3')
+    const req = new Request(reqURL.toString(), { method: 'POST' })
+    await worker.fetch(req, workerEnv)
+    const url = new URL(receivedReqURL)
+    expect(url.search).toBe(
+      '?someKey=someValue' +
+        '&ii=fingerprintjs-pro-react%2Fv1.2.3' +
+        '&ii=fingerprintjs-pro-cloudflare%2F__current_worker_version__%2Fingress',
+    )
+  })
+})
+
+describe('ingress API request headers', () => {
+  let fetchSpy: jest.MockInstance<Promise<Response>, any>
+  const reqURL = new URL('https://example.com/worker_path/get_result')
+  let receivedHeaders: Headers
+
+  beforeAll(() => {
+    fetchSpy = jest.spyOn(globalThis, 'fetch')
+    fetchSpy.mockImplementation(async (input, init) => {
+      const req = new Request(input, init)
+      receivedHeaders = req.headers
+
+      return new Response('')
+    })
+  })
+
+  beforeEach(() => {
+    receivedHeaders = new Headers()
+  })
+
+  afterAll(() => {
+    fetchSpy.mockRestore()
+  })
+
+  test('req headers are the same (except Cookie) when no proxy secret', async () => {
     const workerEnv: WorkerEnv = {
       WORKER_PATH: 'worker_path',
       PROXY_SECRET: null,
       GET_RESULT_PATH: 'get_result',
       AGENT_SCRIPT_DOWNLOAD_PATH: 'agent_download',
     }
-    const response = await worker.fetch(req, workerEnv)
-    const responseBody = (await response.json()) as any
-    const reqHeaders = new Headers(responseBody.reqHeaders)
-    expect(reqHeaders.get('FPJS-Proxy-Secret')).toBe(null)
-    expect(reqHeaders.get('FPJS-Proxy-Client-IP')).toBe(null)
+    const reqHeaders = new Headers({
+      accept: '*/*',
+      'cache-control': 'no-cache',
+      'accept-language': 'en-US',
+      'user-agent': 'Mozilla/5.0',
+      'x-some-header': 'some value',
+      'cf-connecting-ip': '203.0.113.195',
+      'x-forwarded-for': '203.0.113.195, 2001:db8:85a3:8d3:1319:8a2e:370:7348',
+    })
+    const req = new Request(reqURL.toString(), { headers: reqHeaders, method: 'POST' })
+    await worker.fetch(req, workerEnv)
+    receivedHeaders.forEach((value, key) => {
+      console.log({ key, value })
+      expect(reqHeaders.get(key)).toBe(value)
+    })
+    reqHeaders.forEach((value, key) => {
+      expect(receivedHeaders.get(key)).toBe(value)
+    })
   })
-  // test('proxy secret client IP', async () => {
-  //   fetchSpy.mockImplementation(async (input, init) => {
-  //     const req = new Request(input, init)
-  //     const bodyObject = {
-  //       reqHeaders: Object.fromEntries(req.headers),
-  //     }
-  //     return new Response(JSON.stringify(bodyObject))
-  //   })
-  //   const mf = new Miniflare({
-  //     packagePath: true,
-  //     wranglerConfigPath: true,
-  //     async metaProvider() {
-  //       return {
-  //         realIp: '100.101.102.103',
-  //       }
-  //     },
-  //   })
-  //   const response = await mf.dispatchFetch('http://localhost:8787')
-  //   const responseBody = (await response.json()) as any
-  //   const reqHeaders = new Headers(responseBody.reqHeaders)
-  //   expect(reqHeaders.get('FPJS-Proxy-Client-IP')).toBe('100.101.102.103')
-  // })
-  test('eu region', async () => {
+  test('req headers are correct when proxy secret is set', async () => {
+    const reqHeaders = new Headers({
+      accept: '*/*',
+      'cache-control': 'no-cache',
+      'accept-language': 'en-US',
+      'user-agent': 'Mozilla/5.0',
+      'x-some-header': 'some value',
+      'cf-connecting-ip': '203.0.113.195',
+      'x-forwarded-for': '203.0.113.195, 2001:db8:85a3:8d3:1319:8a2e:370:7348',
+    })
+    const req = new Request(reqURL.toString(), { headers: reqHeaders, method: 'POST' })
+    await worker.fetch(req, workerEnv)
+    const expectedHeaders = new Headers(reqHeaders)
+    expectedHeaders.set('FPJS-Proxy-Secret', 'proxy_secret')
+    expectedHeaders.set('FPJS-Proxy-Client-IP', '203.0.113.195')
+    receivedHeaders.forEach((value, key) => {
+      expect(expectedHeaders.get(key)).toBe(value)
+    })
+    expectedHeaders.forEach((value, key) => {
+      expect(receivedHeaders.get(key)).toBe(value)
+    })
+  })
+  test('req headers do not have cookies except _iidt', async () => {
+    const reqHeaders = new Headers({
+      accept: '*/*',
+      'cache-control': 'no-cache',
+      'accept-language': 'en-US',
+      'user-agent': 'Mozilla/5.0',
+      'x-some-header': 'some value',
+      cookie:
+        '_iidt=GlMQaHMfzYvomxCuA7Uymy7ArmjH04jPkT+enN7j/Xk8tJG+UYcQV+Qw60Ry4huw9bmDoO/smyjQp5vLCuSf8t4Jow==; auth_token=123456',
+    })
+    const req = new Request(reqURL.toString(), { headers: reqHeaders, method: 'POST' })
+    await worker.fetch(req, workerEnv)
+    expect(receivedHeaders.get('cookie')).toBe(
+      '_iidt=GlMQaHMfzYvomxCuA7Uymy7ArmjH04jPkT+enN7j/Xk8tJG+UYcQV+Qw60Ry4huw9bmDoO/smyjQp5vLCuSf8t4Jow==',
+    )
+  })
+})
+
+describe('ingress API request body', () => {
+  let fetchSpy: jest.MockInstance<Promise<Response>, any>
+  const reqURL = new URL('https://example.com/worker_path/get_result')
+  let receivedBody = ''
+
+  beforeAll(() => {
+    fetchSpy = jest.spyOn(globalThis, 'fetch')
     fetchSpy.mockImplementation(async (input, init) => {
       const req = new Request(input, init)
-      const bodyObject = {
-        url: req.url,
-      }
-      return new Response(JSON.stringify(bodyObject))
+      receivedBody = await req.text()
+
+      return new Response('')
     })
-    const req = new Request(
-      'https://example.com/worker_path/get_result?ii=fingerprintjs-pro-cloudflare%2Fv1.0.0%2Fprocdn&a=b&region=eu',
-      {
-        headers: {
-          cookie:
-            '_iidt=GlMQaHMfzYvomxCuA7Uymy7ArmjH04jPkT+enN7j/Xk8tJG+UYcQV+Qw60Ry4huw9bmDoO/smyjQp5vLCuSf8t4Jow==; auth_token=123456',
-        },
-      },
-    )
-    const response = await worker.fetch(req, workerEnv)
-    const responseBody = (await response.json()) as any
-    const url = new URL(responseBody.url)
-    expect(url.origin).toBe('https://eu.api.fpjs.io')
   })
-  test('ap region', async () => {
+
+  beforeEach(() => {
+    receivedBody = ''
+  })
+
+  afterAll(() => {
+    fetchSpy.mockRestore()
+  })
+
+  test('request body is not modified', async () => {
+    const reqBody = 'some request body'
+    const req = new Request(reqURL.toString(), { body: reqBody, method: 'POST' })
+    await worker.fetch(req, workerEnv)
+    expect(receivedBody).toBe(reqBody)
+  })
+})
+
+describe('agent download request HTTP method', () => {
+  let fetchSpy: jest.MockInstance<Promise<Response>, any>
+  const reqURL = new URL('https://example.com/worker_path/get_result')
+  let requestMethod: string
+
+  beforeAll(() => {
+    fetchSpy = jest.spyOn(globalThis, 'fetch')
     fetchSpy.mockImplementation(async (input, init) => {
       const req = new Request(input, init)
-      const bodyObject = {
-        url: req.url,
-      }
-      return new Response(JSON.stringify(bodyObject))
+      requestMethod = req.method
+
+      return new Response('')
     })
-    const req = new Request(
-      'https://example.com/worker_path/get_result?ii=fingerprintjs-pro-cloudflare%2Fv1.0.0%2Fprocdn&a=b&region=ap',
-      {
-        headers: {
-          cookie:
-            '_iidt=GlMQaHMfzYvomxCuA7Uymy7ArmjH04jPkT+enN7j/Xk8tJG+UYcQV+Qw60Ry4huw9bmDoO/smyjQp5vLCuSf8t4Jow==; auth_token=123456',
-        },
-      },
-    )
-    const response = await worker.fetch(req, workerEnv)
-    const responseBody = (await response.json()) as any
-    const url = new URL(responseBody.url)
-    expect(url.origin).toBe('https://ap.api.fpjs.io')
   })
-  test('failure response', async () => {
+
+  beforeEach(() => {
+    requestMethod = ''
+  })
+
+  afterAll(() => {
+    fetchSpy.mockRestore()
+  })
+
+  test('when method is GET', async () => {
+    const req = new Request(reqURL.toString(), { method: 'GET' })
+    await worker.fetch(req, workerEnv)
+    expect(requestMethod).toBe('GET')
+  })
+
+  test('when method is POST', async () => {
+    const req = new Request(reqURL.toString(), { method: 'POST' })
+    await worker.fetch(req, workerEnv)
+    expect(requestMethod).toBe('POST')
+  })
+})
+
+describe('ingress API response headers', () => {
+  let fetchSpy: jest.MockInstance<Promise<Response>, any>
+
+  beforeAll(() => {
+    fetchSpy = jest.spyOn(globalThis, 'fetch')
+  })
+
+  afterAll(() => {
+    fetchSpy.mockRestore()
+  })
+
+  test('cookies are the same except domain is set to be first party, the domain is derived from the req url', async () => {
     fetchSpy.mockImplementation(async () => {
-      return new Response('some error', { status: 500, headers: { 'content-type': 'text/plain; charset=UTF-8' } })
+      const headers = new Headers({
+        origin: 'https://some-other.com',
+        'set-cookie':
+          '_iidt=GlMQaHMfzYvomxCuA7Uymy7ArmjH04jPkT+enN7j/Xk8tJG+UYcQV+Qw60Ry4huw9bmDoO/smyjQp5vLCuSf8t4Jow==; Path=/; Domain=fpjs.io; Expires=Fri, 19 Jan 2024 08:54:36 GMT; HttpOnly; Secure; SameSite=None, anotherCookie=anotherValue; Domain=fpjs.io;',
+      })
+      return new Response('', { headers })
     })
     const req = new Request('https://example.com/worker_path/get_result')
     const response = await worker.fetch(req, workerEnv)
-    expect(response.headers.get('content-type')).toBe('text/plain; charset=UTF-8')
+    expect(response.headers.get('set-cookie')).toBe(
+      '_iidt=GlMQaHMfzYvomxCuA7Uymy7ArmjH04jPkT+enN7j/Xk8tJG+UYcQV+Qw60Ry4huw9bmDoO/smyjQp5vLCuSf8t4Jow==; Path=/; Domain=example.com; Expires=Fri, 19 Jan 2024 08:54:36 GMT; HttpOnly; Secure; SameSite=None, anotherCookie=anotherValue; Domain=example.com',
+    )
+  })
+  test('response headers are the same (except HSTS and set-cookie)', async () => {
+    const responseHeaders = new Headers({
+      'access-control-allow-credentials': 'true',
+      'access-control-expose-headers': 'Retry-After',
+      'content-type': 'text/plain',
+    })
+    fetchSpy.mockImplementation(async () => {
+      return new Response('', { headers: responseHeaders })
+    })
+    const req = new Request('https://example.com/worker_path/get_result')
+    const response = await worker.fetch(req, workerEnv)
+    response.headers.forEach((value, key) => {
+      expect(responseHeaders.get(key)).toBe(value)
+    })
+    responseHeaders.forEach((value, key) => {
+      expect(response.headers.get(key)).toBe(value)
+    })
+  })
+  test('strict-transport-security is removed', async () => {
+    fetchSpy.mockImplementation(async () => {
+      const headers = new Headers({
+        'strict-transport-security': 'max-age=63072000',
+      })
+      return new Response('', { headers })
+    })
+    const req = new Request('https://example.com/worker_path/get_result')
+    const response = await worker.fetch(req, workerEnv)
+    expect(response.headers.get('strict-transport-security')).toBe(null)
+  })
+})
+
+describe('ingress API response body when successful', () => {
+  let fetchSpy: jest.MockInstance<Promise<Response>, any>
+
+  beforeAll(() => {
+    fetchSpy = jest.spyOn(globalThis, 'fetch')
+  })
+
+  afterAll(() => {
+    fetchSpy.mockRestore()
+  })
+
+  test('body is unchanged', async () => {
+    fetchSpy.mockImplementation(async () => {
+      return new Response('some text')
+    })
+    const req = new Request('https://example.com/worker_path/get_result')
+    const response = await worker.fetch(req, workerEnv)
+    expect(await response.text()).toBe('some text')
+  })
+})
+
+describe('ingress API response when failure', () => {
+  let fetchSpy: jest.MockInstance<Promise<Response>, any>
+
+  beforeAll(() => {
+    fetchSpy = jest.spyOn(globalThis, 'fetch')
+  })
+
+  afterAll(() => {
+    fetchSpy.mockRestore()
+  })
+
+  test('body and headers are unchanged when ingress API fails', async () => {
+    const responseHeaders = new Headers({
+      'access-control-allow-credentials': 'true',
+      'access-control-expose-headers': 'Retry-After',
+      'content-type': 'text/plain',
+    })
+    fetchSpy.mockImplementation(async () => {
+      return new Response('some error', { status: 500, headers: responseHeaders })
+    })
+    const req = new Request('https://example.com/worker_path/get_result')
+    const response = await worker.fetch(req, workerEnv)
     expect(response.status).toBe(500)
     expect(await response.text()).toBe('some error')
+    response.headers.forEach((value, key) => {
+      expect(responseHeaders.get(key)).toBe(value)
+    })
+    responseHeaders.forEach((value, key) => {
+      expect(response.headers.get(key)).toBe(value)
+    })
   })
-  test('error response', async () => {
+  test('error response when error inside the worker', async () => {
     fetchSpy.mockImplementation(async () => {
       throw new Error('some error')
     })
-    const req = new Request('https://example.com/worker_path/get_result', {
-      headers: { origin: 'https://example.com' },
-    })
+    const req = new Request('https://example.com/worker_path/get_result')
     const response = await worker.fetch(req, workerEnv)
     expect(response.headers.get('content-type')).toBe('application/json')
     expect(response.status).toBe(500)
-    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://example.com')
-    expect(response.headers.get('Access-Control-Allow-Credentials')).toBe('true')
-    const responseBody = (await response.json()) as unknown as FPJSResponse
+    const responseBody = (await response.json()) as FPJSResponse
     const expectedResponseBody: Omit<FPJSResponse, 'requestId'> = {
       v: '2',
       error: {

--- a/test/endpoints/status.test.ts
+++ b/test/endpoints/status.test.ts
@@ -1,0 +1,16 @@
+import worker from '../../src'
+import { WorkerEnv } from '../../src/env'
+
+describe('status', () => {
+  test('renders the status page', async () => {
+    const workerEnv: WorkerEnv = {
+      WORKER_PATH: 'worker_path',
+      PROXY_SECRET: null,
+      GET_RESULT_PATH: 'get_result',
+      AGENT_SCRIPT_DOWNLOAD_PATH: 'agent_download',
+    }
+    const req = new Request('http://localhost/worker_path/status')
+    const response = await worker.fetch(req, workerEnv)
+    expect(await response.text()).toMatchSnapshot()
+  })
+})

--- a/test/utils/getCacheControlHeaderWithMaxAgeIfLower.test.ts
+++ b/test/utils/getCacheControlHeaderWithMaxAgeIfLower.test.ts
@@ -9,7 +9,7 @@ describe('getCacheControlHeaderWithMaxAgeIfLower', () => {
     expect(f('public, max-age=3600, s-maxage=633059', 6000, 100)).toBe('public, max-age=3600, s-maxage=100')
   })
   test('if maxAge is absent then use maxMaxAge', () => {
-    expect(f('public', 6000, 100)).toBe('public, max-age=6000, s-maxage=60')
+    expect(f('public', 6000, 100)).toBe('public, max-age=6000, s-maxage=100')
   })
   test('if s-maxAge < maxSMaxAge then use maxSMaxAge', () => {
     expect(f('public, max-age=3600, s-maxage=3600', 1200, 1200)).toBe('public, max-age=1200, s-maxage=1200')

--- a/test/utils/getCacheControlHeaderWithMaxAgeIfLower.test.ts
+++ b/test/utils/getCacheControlHeaderWithMaxAgeIfLower.test.ts
@@ -3,21 +3,21 @@ import { getCacheControlHeaderWithMaxAgeIfLower } from '../../src/utils'
 describe('getCacheControlHeaderWithMaxAgeIfLower', () => {
   const f = getCacheControlHeaderWithMaxAgeIfLower
   test('if maxAge < maxMaxAge then use maxAge', () => {
-    expect(f('public, max-age=3600, s-maxage=633059', 1200)).toBe('public, max-age=1200, s-maxage=1200')
+    expect(f('public, max-age=3600, s-maxage=633059', 1200, 100)).toBe('public, max-age=1200, s-maxage=100')
   })
   test('if maxAge > maxMaxAge then use maxMaxAge', () => {
-    expect(f('public, max-age=3600, s-maxage=633059', 6000)).toBe('public, max-age=3600, s-maxage=6000')
+    expect(f('public, max-age=3600, s-maxage=633059', 6000, 100)).toBe('public, max-age=3600, s-maxage=100')
   })
   test('if maxAge is absent then use maxMaxAge', () => {
-    expect(f('public', 6000)).toBe('public, max-age=6000, s-maxage=6000')
+    expect(f('public', 6000, 100)).toBe('public, max-age=6000, s-maxage=60')
   })
-  test('if s-maxAge < maxMaxAge then use maxAge', () => {
-    expect(f('public, max-age=3600, s-maxage=3600', 1200)).toBe('public, max-age=1200, s-maxage=1200')
+  test('if s-maxAge < maxSMaxAge then use maxSMaxAge', () => {
+    expect(f('public, max-age=3600, s-maxage=3600', 1200, 1200)).toBe('public, max-age=1200, s-maxage=1200')
   })
-  test('if s-maxAge > maxMaxAge then use maxMaxAge', () => {
-    expect(f('public, max-age=3600, s-maxage=3600', 6000)).toBe('public, max-age=3600, s-maxage=3600')
+  test('if s-maxAge > maxMaxAge then use s-MaxAge', () => {
+    expect(f('public, max-age=3600, s-maxage=3600', 6000, 6000)).toBe('public, max-age=3600, s-maxage=3600')
   })
-  test('if s-maxAge is absent then use maxMaxAge', () => {
-    expect(f('public', 6000)).toBe('public, max-age=6000, s-maxage=6000')
+  test('if s-maxAge is absent then use maxSMaxAge', () => {
+    expect(f('public', 6000, 6000)).toBe('public, max-age=6000, s-maxage=6000')
   })
 })

--- a/test/utils/proxyEndpoint.test.ts
+++ b/test/utils/proxyEndpoint.test.ts
@@ -36,12 +36,20 @@ describe('getAgentScriptEndpoint', () => {
 
 describe('getVisitorIdEndpoint', () => {
   test('us region', () => {
-    expect(getVisitorIdEndpoint('us')).toBe('https://api.fpjs.io')
+    let urlSearchParams = new URLSearchParams()
+    expect(getVisitorIdEndpoint(urlSearchParams)).toBe('https://api.fpjs.io')
+    urlSearchParams = new URLSearchParams()
+    urlSearchParams.set('region', 'us')
+    expect(getVisitorIdEndpoint(urlSearchParams)).toBe('https://api.fpjs.io')
   })
   test('eu region', () => {
-    expect(getVisitorIdEndpoint('eu')).toBe('https://eu.api.fpjs.io')
+    const urlSearchParams = new URLSearchParams()
+    urlSearchParams.set('region', 'eu')
+    expect(getVisitorIdEndpoint(urlSearchParams)).toBe('https://eu.api.fpjs.io')
   })
   test('ap region', () => {
-    expect(getVisitorIdEndpoint('ap')).toBe('https://ap.api.fpjs.io')
+    const urlSearchParams = new URLSearchParams()
+    urlSearchParams.set('region', 'ap')
+    expect(getVisitorIdEndpoint(urlSearchParams)).toBe('https://ap.api.fpjs.io')
   })
 })


### PR DESCRIPTION
- Fixed `content-type` of the error responses when the worker throws an error
- Fixed Pro CDN requests lose search parameters
- Changed `s-maxage` of the Pro CDN response's caching from 3600 to 60
- Refactored `handleIngressAPI`. Removed `handleIngressAPIRaw` function and made `makeIngressAPIRequest` and `makeDownloadScriptRequest` similar looking to improve readability
- Refactored some other functions, removed unnecessary `async` keywords
- Added tests for agent download and ingress API requests. The tests are in separate `describe` blocks that form some sort of documentation for the purpose of these proxy requests (see screenshots).
- Updated test coverage to apply for the whole `src` folder.

Note: The health endpoint will be removed and the status page will have more tests in a separate PR.

![getResultTests](https://user-images.githubusercontent.com/11958773/214322537-70f08e82-23cb-4ff9-be6c-a7b657beaaca.png)
![agentDownloadTests](https://user-images.githubusercontent.com/11958773/214322546-39c775e9-5aaa-4549-9c12-05c985db3854.png)
