### PR TITLE
Browser Cache API handling

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -37,7 +37,7 @@ export const isGetResultPathSet = isVarSet(getResultPathVarName)
 
 export function getGetResultPath(env: WorkerEnv): string {
   const getResultPathVar = getGetResultPathVar(env)
-  return `/${getResultPathVar}`
+  return `/${getResultPathVar}(/.*)?`
 }
 
 export const proxySecretVarName = 'PROXY_SECRET'

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -5,7 +5,11 @@ import { createRoute } from './utils'
 
 export type Route = {
   pathPattern: RegExp
-  handler: (request: Request, env: WorkerEnv) => Response | Promise<Response>
+  handler: (
+    request: Request,
+    env: WorkerEnv,
+    routeMatchArray: RegExpMatchArray | undefined,
+  ) => Response | Promise<Response>
 }
 
 function createRoutes(env: WorkerEnv): Route[] {
@@ -47,8 +51,9 @@ export function handleRequestWithRoutes(
 ): Promise<Response> | Response {
   const url = new URL(request.url)
   for (const route of routes) {
-    if (url.pathname.match(route.pathPattern)) {
-      return route.handler(request, env)
+    const matches = url.pathname.match(route.pathPattern)
+    if (matches) {
+      return route.handler(request, env, matches)
     }
   }
 

--- a/src/handlers/handleDownloadScript.ts
+++ b/src/handlers/handleDownloadScript.ts
@@ -4,7 +4,7 @@ import {
   createErrorResponseForProCDN,
   getAgentScriptEndpoint,
 } from '../utils'
-import { createResponseWithMaxAge } from '../utils/createResponseWithMaxAge'
+import { createResponseWithMaxAge } from '../utils'
 
 function copySearchParams(oldURL: URL, newURL: URL): void {
   newURL.search = new URLSearchParams(oldURL.search).toString()

--- a/src/handlers/handleDownloadScript.ts
+++ b/src/handlers/handleDownloadScript.ts
@@ -1,25 +1,13 @@
 import {
   fetchCacheable,
-  getCacheControlHeaderWithMaxAgeIfLower,
   addTrafficMonitoringSearchParamsForProCDN,
   createErrorResponseForProCDN,
   getAgentScriptEndpoint,
 } from '../utils'
+import { createResponseWithMaxAge } from '../utils/createResponseWithMaxAge'
 
 function copySearchParams(oldURL: URL, newURL: URL): void {
   newURL.search = new URLSearchParams(oldURL.search).toString()
-}
-
-function createResponseWithMaxAge(oldResponse: Response, maxMaxAge: number, maxSMaxAge: number): Response {
-  const response = new Response(oldResponse.body, oldResponse)
-  const oldCacheControlHeader = oldResponse.headers.get('cache-control')
-  if (!oldCacheControlHeader) {
-    return response
-  }
-
-  const cacheControlHeader = getCacheControlHeaderWithMaxAgeIfLower(oldCacheControlHeader, maxMaxAge, maxSMaxAge)
-  response.headers.set('cache-control', cacheControlHeader)
-  return response
 }
 
 function makeDownloadScriptRequest(request: Request): Promise<Response> {
@@ -34,7 +22,7 @@ function makeDownloadScriptRequest(request: Request): Promise<Response> {
 
   console.log(`Downloading script from cdnEndpoint ${newURL.toString()}...`)
   const newRequest = new Request(newURL.toString(), new Request(request, { headers }))
-  const workerCacheTtl = 5 * 60
+  const workerCacheTtl = 60
   const maxMaxAge = 60 * 60
   const maxSMaxAge = 60
 

--- a/src/handlers/handleDownloadScript.ts
+++ b/src/handlers/handleDownloadScript.ts
@@ -1,7 +1,7 @@
 import {
   fetchCacheable,
   addTrafficMonitoringSearchParamsForProCDN,
-  createErrorResponseForProCDN,
+  createFallbackErrorResponse,
   getAgentScriptEndpoint,
   createResponseWithMaxAge,
 } from '../utils'
@@ -33,6 +33,6 @@ export async function handleDownloadScript(request: Request): Promise<Response> 
   try {
     return await makeDownloadScriptRequest(request)
   } catch (e) {
-    return createErrorResponseForProCDN(e)
+    return createFallbackErrorResponse(e)
   }
 }

--- a/src/handlers/handleDownloadScript.ts
+++ b/src/handlers/handleDownloadScript.ts
@@ -3,8 +3,8 @@ import {
   addTrafficMonitoringSearchParamsForProCDN,
   createErrorResponseForProCDN,
   getAgentScriptEndpoint,
+  createResponseWithMaxAge,
 } from '../utils'
-import { createResponseWithMaxAge } from '../utils'
 
 function copySearchParams(oldURL: URL, newURL: URL): void {
   newURL.search = new URLSearchParams(oldURL.search).toString()

--- a/src/handlers/handleIngressAPI.ts
+++ b/src/handlers/handleIngressAPI.ts
@@ -10,7 +10,7 @@ import {
   getVisitorIdEndpoint,
   fetchCacheable,
 } from '../utils'
-import { createResponseWithMaxAge } from '../utils/createResponseWithMaxAge'
+import { createResponseWithMaxAge } from '../utils'
 
 declare global {
   interface Headers {

--- a/src/handlers/handleIngressAPI.ts
+++ b/src/handlers/handleIngressAPI.ts
@@ -76,7 +76,7 @@ async function makeIngressRequest(
   return fetch(request).then((response) => createResponseWithFirstPartyCookies(receivedRequest, response))
 }
 
-function makeCacheRequest(receivedRequest: Request, routeMatches: RegExpMatchArray | undefined) {
+function makeCacheEndpointRequest(receivedRequest: Request, routeMatches: RegExpMatchArray | undefined) {
   const requestURL = createRequestURL(receivedRequest.url, routeMatches)
   const headers = new Headers(receivedRequest.headers)
   headers.delete('Cookie')
@@ -96,7 +96,7 @@ function makeCacheRequest(receivedRequest: Request, routeMatches: RegExpMatchArr
 export async function handleIngressAPI(request: Request, env: WorkerEnv, routeMatches: RegExpMatchArray | undefined) {
   if (request.method === 'GET') {
     try {
-      return await makeCacheRequest(request, routeMatches)
+      return await makeCacheEndpointRequest(request, routeMatches)
     } catch (e) {
       return createFallbackErrorResponse(e)
     }

--- a/src/handlers/handleIngressAPI.ts
+++ b/src/handlers/handleIngressAPI.ts
@@ -46,9 +46,10 @@ function createResponseWithFirstPartyCookies(request: Request, response: Respons
   })
 }
 
-async function makeIngressAPIRequest(request: Request, env: WorkerEnv) {
+async function makeIngressAPIRequest(request: Request, env: WorkerEnv, routeMatches: RegExpMatchArray | undefined) {
+  const routeSuffix = routeMatches ? routeMatches[1] : undefined
   const oldURL = new URL(request.url)
-  const endpoint = getVisitorIdEndpoint(oldURL.searchParams)
+  const endpoint = getVisitorIdEndpoint(oldURL.searchParams, routeSuffix)
   const newURL = new URL(endpoint)
   copySearchParams(oldURL, newURL)
   addTrafficMonitoringSearchParamsForVisitorIdRequest(newURL)
@@ -63,9 +64,9 @@ async function makeIngressAPIRequest(request: Request, env: WorkerEnv) {
   return fetch(newRequest).then((response) => createResponseWithFirstPartyCookies(request, response))
 }
 
-export async function handleIngressAPI(request: Request, env: WorkerEnv) {
+export async function handleIngressAPI(request: Request, env: WorkerEnv, routeMatches: RegExpMatchArray | undefined) {
   try {
-    return await makeIngressAPIRequest(request, env)
+    return await makeIngressAPIRequest(request, env, routeMatches)
   } catch (e) {
     return createErrorResponseForIngress(request, e)
   }

--- a/src/handlers/handleIngressAPI.ts
+++ b/src/handlers/handleIngressAPI.ts
@@ -70,7 +70,9 @@ async function makeIngressRequest(
   headers = filterCookies(headers, (key) => key === '_iidt')
   addProxyIntegrationHeaders(headers, env)
   const body = await (receivedRequest.headers.get('Content-Type') ? receivedRequest.blob() : Promise.resolve(null))
+  console.log(`sending ingress request to ${requestURL}...`)
   const request = new Request(requestURL, new Request(receivedRequest, { headers, body }))
+
   return fetch(request).then((response) => createResponseWithFirstPartyCookies(receivedRequest, response))
 }
 
@@ -79,6 +81,7 @@ function makeCacheRequest(receivedRequest: Request, routeMatches: RegExpMatchArr
   const headers = new Headers(receivedRequest.headers)
   headers.delete('Cookie')
 
+  console.log(`sending cache request to ${requestURL}...`)
   const request = new Request(requestURL, new Request(receivedRequest, { headers }))
 
   const workerCacheTtl = 60

--- a/src/utils/createErrorResponse.ts
+++ b/src/utils/createErrorResponse.ts
@@ -64,7 +64,7 @@ export function createErrorResponseForIngress(request: Request, error: string | 
   return new Response(JSON.stringify(responseBody), { status: 500, headers: responseHeaders })
 }
 
-export function createErrorResponseForProCDN(error: string | Error | unknown): Response {
+export function createFallbackErrorResponse(error: string | Error | unknown): Response {
   const responseBody = { error: errorToString(error) }
   return new Response(JSON.stringify(responseBody), { status: 500, headers: { 'content-type': 'application/json' } })
 }

--- a/src/utils/createResponseWithMaxAge.ts
+++ b/src/utils/createResponseWithMaxAge.ts
@@ -1,0 +1,13 @@
+import { getCacheControlHeaderWithMaxAgeIfLower } from './getCacheControlHeaderWithMaxAgeIfLower'
+
+export function createResponseWithMaxAge(oldResponse: Response, maxMaxAge: number, maxSMaxAge: number): Response {
+  const response = new Response(oldResponse.body, oldResponse)
+  const oldCacheControlHeader = oldResponse.headers.get('cache-control')
+  if (!oldCacheControlHeader) {
+    return response
+  }
+
+  const cacheControlHeader = getCacheControlHeaderWithMaxAgeIfLower(oldCacheControlHeader, maxMaxAge, maxSMaxAge)
+  response.headers.set('cache-control', cacheControlHeader)
+  return response
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,7 +1,7 @@
 export { getCacheControlHeaderWithMaxAgeIfLower } from './getCacheControlHeaderWithMaxAgeIfLower'
 export {
   createErrorResponseForIngress,
-  createErrorResponseForProCDN,
+  createFallbackErrorResponse,
   ErrorData,
   FPJSResponse,
   Notification,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,35 +1,27 @@
-import { getCacheControlHeaderWithMaxAgeIfLower } from './getCacheControlHeaderWithMaxAgeIfLower'
-import { createErrorResponseForIngress, createErrorResponseForProCDN } from './createErrorResponse'
-import { fetchCacheable } from './fetchCacheable'
-import {
+export { getCacheControlHeaderWithMaxAgeIfLower } from './getCacheControlHeaderWithMaxAgeIfLower'
+export {
+  createErrorResponseForIngress,
+  createErrorResponseForProCDN,
+  ErrorData,
+  FPJSResponse,
+  Notification,
+} from './createErrorResponse'
+export { fetchCacheable } from './fetchCacheable'
+export {
   addTrafficMonitoringSearchParamsForVisitorIdRequest,
   addTrafficMonitoringSearchParamsForProCDN,
 } from './addTrafficMonitoring'
-import { returnHttpResponse } from './returnHttpResponse'
-import { addProxyIntegrationHeaders } from './addProxyIntegrationHeaders'
-import { getEffectiveTLDPlusOne } from './getEffectiveTLDPlusOne'
-import { Cookie, createCookieStringFromObject, createCookieObjectFromHeaderValue, filterCookies } from './cookie'
-import { createRoute, addTrailingWildcard, removeTrailingSlashesAndMultiSlashes, replaceDot } from './routing'
-import { getAgentScriptEndpoint, getVisitorIdEndpoint } from './proxyEndpoint'
-
+export { returnHttpResponse } from './returnHttpResponse'
+export { addProxyIntegrationHeaders } from './addProxyIntegrationHeaders'
+export { getEffectiveTLDPlusOne } from './getEffectiveTLDPlusOne'
+export { Cookie, createCookieStringFromObject, createCookieObjectFromHeaderValue, filterCookies } from './cookie'
 export {
-  createCookieStringFromObject,
-  getCacheControlHeaderWithMaxAgeIfLower,
-  addTrafficMonitoringSearchParamsForVisitorIdRequest,
-  addTrafficMonitoringSearchParamsForProCDN,
-  createCookieObjectFromHeaderValue,
-  createErrorResponseForIngress,
-  createErrorResponseForProCDN,
-  addProxyIntegrationHeaders,
+  createRoute,
   addTrailingWildcard,
   removeTrailingSlashesAndMultiSlashes,
   replaceDot,
-  getEffectiveTLDPlusOne,
-  returnHttpResponse,
-  filterCookies,
-  fetchCacheable,
-  createRoute,
-  getAgentScriptEndpoint,
-  getVisitorIdEndpoint,
-  Cookie,
-}
+  addPathnameMatchBeforeRoute,
+  addEndingTrailingSlashToRoute,
+} from './routing'
+export { getAgentScriptEndpoint, getVisitorIdEndpoint } from './proxyEndpoint'
+export { createResponseWithMaxAge } from './createResponseWithMaxAge'

--- a/src/utils/proxyEndpoint.ts
+++ b/src/utils/proxyEndpoint.ts
@@ -18,6 +18,6 @@ export function getVisitorIdEndpoint(
 ): string {
   const region = searchParams.get('region') || 'us'
   const prefix = region === DEFAULT_REGION ? '' : `${region}.`
-  const suffix = pathSuffix ? pathSuffix : ''
+  const suffix = pathSuffix ?? ''
   return `https://${prefix}api.fpjs.io${suffix}`
 }

--- a/src/utils/proxyEndpoint.ts
+++ b/src/utils/proxyEndpoint.ts
@@ -12,8 +12,12 @@ export function getAgentScriptEndpoint(searchParams: URLSearchParams): string {
   return `${base}${lv}`
 }
 
-export function getVisitorIdEndpoint(searchParams: URLSearchParams): string {
+export function getVisitorIdEndpoint(
+  searchParams: URLSearchParams,
+  pathSuffix: string | undefined = undefined,
+): string {
   const region = searchParams.get('region') || 'us'
   const prefix = region === DEFAULT_REGION ? '' : `${region}.`
-  return `https://${prefix}api.fpjs.io`
+  const suffix = pathSuffix ? `/${pathSuffix}` : ''
+  return `https://${prefix}api.fpjs.io${suffix}`
 }

--- a/src/utils/proxyEndpoint.ts
+++ b/src/utils/proxyEndpoint.ts
@@ -18,6 +18,6 @@ export function getVisitorIdEndpoint(
 ): string {
   const region = searchParams.get('region') || 'us'
   const prefix = region === DEFAULT_REGION ? '' : `${region}.`
-  const suffix = pathSuffix ? `/${pathSuffix}` : ''
+  const suffix = pathSuffix ? pathSuffix : ''
   return `https://${prefix}api.fpjs.io${suffix}`
 }

--- a/test/endpoints/agentDownload.test.ts
+++ b/test/endpoints/agentDownload.test.ts
@@ -254,7 +254,7 @@ describe('agent download request cache durations', () => {
     const response = await worker.fetch(req, workerEnv)
     expect(response.headers.get('cache-control')).toBe('public, max-age=3600, s-maxage=10')
   })
-  test('cloudflare network cache is set to 5 mins', async () => {
+  test('cloudflare network cache is set to 1 min', async () => {
     fetchSpy.mockImplementation(async (_, init) => {
       receivedCfObject = (init as RequestInit).cf
       const responseHeaders = new Headers({

--- a/test/endpoints/agentDownload.test.ts
+++ b/test/endpoints/agentDownload.test.ts
@@ -265,8 +265,8 @@ describe('agent download request cache durations', () => {
     })
     const req = new Request(reqURL.toString())
     await worker.fetch(req, workerEnv)
-    expect(receivedCfObject).toMatchObject({ cacheTtl: 300 })
-    expect({ cacheTtl: 300 }).toMatchObject(receivedCfObject!)
+    expect(receivedCfObject).toMatchObject({ cacheTtl: 60 })
+    expect({ cacheTtl: 60 }).toMatchObject(receivedCfObject!)
   })
 })
 

--- a/test/endpoints/getResult.test.ts
+++ b/test/endpoints/getResult.test.ts
@@ -64,6 +64,66 @@ describe('ingress API request proxy URL', () => {
   })
 })
 
+describe('ingress API request proxy URL with suffix', () => {
+  let fetchSpy: jest.MockInstance<Promise<Response>, any>
+  let reqURL: URL
+  let receivedReqURL = ''
+
+  beforeAll(() => {
+    fetchSpy = jest.spyOn(globalThis, 'fetch')
+    fetchSpy.mockImplementation(async (input, init) => {
+      const req = new Request(input, init)
+      receivedReqURL = req.url
+      return new Response()
+    })
+  })
+
+  beforeEach(() => {
+    reqURL = new URL('https://example.com/worker_path/get_result/suffix')
+
+    receivedReqURL = ''
+  })
+
+  afterAll(() => {
+    fetchSpy.mockRestore()
+  })
+
+  test('no region', async () => {
+    const req = new Request(reqURL.toString(), { method: 'POST' })
+    await worker.fetch(req, workerEnv)
+    const receivedURL = new URL(receivedReqURL)
+    expect(receivedURL.origin).toBe('https://api.fpjs.io')
+    expect(receivedURL.pathname).toBe('/suffix')
+  })
+
+  test('us region', async () => {
+    reqURL.searchParams.append('region', 'us')
+    const req = new Request(reqURL.toString(), { method: 'POST' })
+    await worker.fetch(req, workerEnv)
+    const receivedURL = new URL(receivedReqURL)
+    expect(receivedURL.origin).toBe('https://api.fpjs.io')
+    expect(receivedURL.pathname).toBe('/suffix')
+  })
+
+  test('eu region', async () => {
+    reqURL.searchParams.append('region', 'eu')
+    const req = new Request(reqURL.toString(), { method: 'POST' })
+    await worker.fetch(req, workerEnv)
+    const receivedURL = new URL(receivedReqURL)
+    expect(receivedURL.origin).toBe('https://eu.api.fpjs.io')
+    expect(receivedURL.pathname).toBe('/suffix')
+  })
+
+  test('ap region', async () => {
+    reqURL.searchParams.append('region', 'ap')
+    const req = new Request(reqURL.toString(), { method: 'POST' })
+    await worker.fetch(req, workerEnv)
+    const receivedURL = new URL(receivedReqURL)
+    expect(receivedURL.origin).toBe('https://ap.api.fpjs.io')
+    expect(receivedURL.pathname).toBe('/suffix')
+  })
+})
+
 describe('ingress API request query parameters', () => {
   let fetchSpy: jest.MockInstance<Promise<Response>, any>
   let reqURL: URL

--- a/test/endpoints/getResult.test.ts
+++ b/test/endpoints/getResult.test.ts
@@ -594,7 +594,7 @@ describe('get result request cache durations', () => {
     const response = await worker.fetch(req, workerEnv)
     expect(response.headers.get('cache-control')).toBe('public, max-age=3600, s-maxage=10')
   })
-  test('cloudflare network cache is set to 5 mins', async () => {
+  test('cloudflare network cache is set to 1 min', async () => {
     fetchSpy.mockImplementation(async (_, init) => {
       receivedCfObject = (init as RequestInit).cf
       const responseHeaders = new Headers({

--- a/test/endpoints/getResult.test.ts
+++ b/test/endpoints/getResult.test.ts
@@ -1,6 +1,6 @@
 import { WorkerEnv } from '../../src/env'
 import worker from '../../src'
-import { FPJSResponse } from '../../src/utils/createErrorResponse'
+import { FPJSResponse } from '../../src/utils'
 
 const workerEnv: WorkerEnv = {
   PROXY_SECRET: 'proxy_secret',

--- a/test/endpoints/getResult.test.ts
+++ b/test/endpoints/getResult.test.ts
@@ -305,10 +305,6 @@ describe('ingress API request body', () => {
     })
   })
 
-  beforeEach(() => {
-    receivedBody = ''
-  })
-
   afterAll(() => {
     fetchSpy.mockRestore()
   })
@@ -763,7 +759,6 @@ describe('POST request cache durations', () => {
     })
     const req = new Request(reqURL.toString(), { method: 'POST' })
     await worker.fetch(req, workerEnv)
-    expect(receivedCfObject).toMatchObject({ cacheTtl: undefined })
-    expect({ cacheTtl: undefined }).toMatchObject(receivedCfObject!)
+    expect(receivedCfObject).toBe(null)
   })
 })

--- a/test/endpoints/getResult.test.ts
+++ b/test/endpoints/getResult.test.ts
@@ -79,7 +79,7 @@ describe('ingress API request proxy URL with suffix', () => {
   })
 
   beforeEach(() => {
-    reqURL = new URL('https://example.com/worker_path/get_result/suffix')
+    reqURL = new URL('https://example.com/worker_path/get_result/suffix/more/path')
 
     receivedReqURL = ''
   })
@@ -93,7 +93,7 @@ describe('ingress API request proxy URL with suffix', () => {
     await worker.fetch(req, workerEnv)
     const receivedURL = new URL(receivedReqURL)
     expect(receivedURL.origin).toBe('https://api.fpjs.io')
-    expect(receivedURL.pathname).toBe('/suffix')
+    expect(receivedURL.pathname).toBe('/suffix/more/path')
   })
 
   test('us region', async () => {
@@ -102,7 +102,7 @@ describe('ingress API request proxy URL with suffix', () => {
     await worker.fetch(req, workerEnv)
     const receivedURL = new URL(receivedReqURL)
     expect(receivedURL.origin).toBe('https://api.fpjs.io')
-    expect(receivedURL.pathname).toBe('/suffix')
+    expect(receivedURL.pathname).toBe('/suffix/more/path')
   })
 
   test('eu region', async () => {
@@ -111,7 +111,7 @@ describe('ingress API request proxy URL with suffix', () => {
     await worker.fetch(req, workerEnv)
     const receivedURL = new URL(receivedReqURL)
     expect(receivedURL.origin).toBe('https://eu.api.fpjs.io')
-    expect(receivedURL.pathname).toBe('/suffix')
+    expect(receivedURL.pathname).toBe('/suffix/more/path')
   })
 
   test('ap region', async () => {
@@ -120,7 +120,7 @@ describe('ingress API request proxy URL with suffix', () => {
     await worker.fetch(req, workerEnv)
     const receivedURL = new URL(receivedReqURL)
     expect(receivedURL.origin).toBe('https://ap.api.fpjs.io')
-    expect(receivedURL.pathname).toBe('/suffix')
+    expect(receivedURL.pathname).toBe('/suffix/more/path')
   })
 })
 

--- a/test/handleRequest/handleRequestWithRoutes.test.ts
+++ b/test/handleRequest/handleRequestWithRoutes.test.ts
@@ -44,6 +44,11 @@ describe('download Pro Agent Script', () => {
     await handleRequestWithRoutes(request, env, routes)
     expect(mockAgentDownloadHandler).toHaveBeenCalledTimes(1)
   })
+  test('with prefix', async () => {
+    const request = new Request(`https://example.com/foobar/${agentScriptDownloadPath}`)
+    await handleRequestWithRoutes(request, env, routes)
+    expect(mockAgentDownloadHandler).toHaveBeenCalled()
+  })
   test('incorrect path', async () => {
     const request = new Request(`https://example.com/${agentScriptDownloadPath}/some-path`)
     await handleRequestWithRoutes(request, env, routes)
@@ -83,8 +88,13 @@ describe('get GetResult', () => {
     await handleRequestWithRoutes(request, env, routes)
     expect(mockIngressAPIHandler).toHaveBeenCalledTimes(1)
   })
+  test('with prefix', async () => {
+    const request = new Request(`https://example.com/foobar/${getResultPath}`)
+    await handleRequestWithRoutes(request, env, routes)
+    expect(mockIngressAPIHandler).toHaveBeenCalled()
+  })
   test('incorrect path', async () => {
-    const request = new Request(`https://example.com/${getResultPath}/some-path`)
+    const request = new Request(`https://example.com/${getResultPath}foobar`)
     await handleRequestWithRoutes(request, env, routes)
     expect(mockIngressAPIHandler).not.toHaveBeenCalled()
   })
@@ -121,6 +131,11 @@ describe('status page', () => {
     const request = new Request(`https://example.com/${workerPath}/status`, { method: 'POST' })
     await handleRequestWithRoutes(request, env, routes)
     expect(mockStatusPageHandler).toHaveBeenCalledTimes(1)
+  })
+  test('with prefix', async () => {
+    const request = new Request(`https://example.com/foobar/status`)
+    await handleRequestWithRoutes(request, env, routes)
+    expect(mockStatusPageHandler).toHaveBeenCalled()
   })
   test('incorrect path', async () => {
     const request = new Request(`https://example.com/status/some-path`)

--- a/test/handleRequest/handleRequestWithRoutes.test.ts
+++ b/test/handleRequest/handleRequestWithRoutes.test.ts
@@ -93,6 +93,11 @@ describe('get GetResult', () => {
     await handleRequestWithRoutes(request, env, routes)
     expect(mockIngressAPIHandler).toHaveBeenCalled()
   })
+  test('with suffix', async () => {
+    const request = new Request(`https://example.com/${getResultPath}/some-path`)
+    await handleRequestWithRoutes(request, env, routes)
+    expect(mockIngressAPIHandler).toHaveBeenCalled()
+  })
   test('incorrect path', async () => {
     const request = new Request(`https://example.com/${getResultPath}foobar`)
     await handleRequestWithRoutes(request, env, routes)

--- a/test/utils/createErrorResponse.test.ts
+++ b/test/utils/createErrorResponse.test.ts
@@ -1,4 +1,4 @@
-import { createErrorResponseForIngress, createErrorResponseForProCDN } from '../../src/utils'
+import { createErrorResponseForIngress, createFallbackErrorResponse } from '../../src/utils'
 import { FPJSResponse } from '../../src/utils'
 
 describe('createErrorResponseForIngress', () => {
@@ -87,11 +87,11 @@ describe('createErrorResponseForIngress', () => {
   })
 })
 
-describe('createErrorResponseForProCDN', () => {
+describe('createFallbackErrorResponse', () => {
   let response: Response
   beforeEach(() => {
     const errorReason = 'some error message'
-    response = createErrorResponseForProCDN(errorReason)
+    response = createFallbackErrorResponse(errorReason)
   })
   test('response body is as expected', async () => {
     expect(response.body).not.toBeNull()

--- a/test/utils/createErrorResponse.test.ts
+++ b/test/utils/createErrorResponse.test.ts
@@ -1,5 +1,5 @@
 import { createErrorResponseForIngress, createErrorResponseForProCDN } from '../../src/utils'
-import { FPJSResponse } from '../../src/utils/createErrorResponse'
+import { FPJSResponse } from '../../src/utils'
 
 describe('createErrorResponseForIngress', () => {
   let response: Response

--- a/test/utils/proxyEndpoint.test.ts
+++ b/test/utils/proxyEndpoint.test.ts
@@ -52,4 +52,9 @@ describe('getVisitorIdEndpoint', () => {
     urlSearchParams.set('region', 'ap')
     expect(getVisitorIdEndpoint(urlSearchParams)).toBe('https://ap.api.fpjs.io')
   })
+  test('no region with suffix', () => {
+    const urlSearchParams = new URLSearchParams()
+    const pathName = '/suffix/more/path'
+    expect(getVisitorIdEndpoint(urlSearchParams, pathName)).toBe('https://api.fpjs.io/suffix/more/path')
+  })
 })

--- a/test/utils/routing.test.ts
+++ b/test/utils/routing.test.ts
@@ -79,7 +79,7 @@ describe('addPathnameMatchBeforeRoute', () => {
   })
 })
 
-describe('createRoute', () => {
+describe('createRoute prefix', () => {
   const matchingRouteCases = [
     '/fpjs-worker-path-0123456789/status',
     '/fpjsworker/status',
@@ -98,5 +98,18 @@ describe('createRoute', () => {
   const unMatchingRouteCases = ['/status/some-path']
   it.each(unMatchingRouteCases)("%s doesn't match /status", (route) => {
     expect(createRoute('/status').test(route)).toBe(false)
+  })
+})
+
+describe('createRoute suffix', () => {
+  const suffixPath = '/ingress(/.*)?'
+  const toBeMatched = ['/ingress', '/ingress/', '/ingress/foo', '/ingress/foo/bar', '/ingress/foo/bar/baz']
+  const toBeFail = ['/ingressfoo', '/ingressfoo/', '/ingressfoo/bar']
+
+  it.each(toBeMatched)('should match with suffix', (suffix) => {
+    expect(createRoute(suffixPath).test(suffix)).toBe(true)
+  })
+  it.each(toBeFail)('should not match with suffix', (suffix) => {
+    expect(createRoute(suffixPath).test(suffix)).toBe(false)
   })
 })

--- a/test/utils/routing.test.ts
+++ b/test/utils/routing.test.ts
@@ -1,5 +1,5 @@
 import { removeTrailingSlashesAndMultiSlashes, addTrailingWildcard, replaceDot, createRoute } from '../../src/utils'
-import { addEndingTrailingSlashToRoute, addPathnameMatchBeforeRoute } from '../../src/utils/routing'
+import { addEndingTrailingSlashToRoute, addPathnameMatchBeforeRoute } from '../../src/utils'
 
 describe('removeTrailingSlashesAndMultiSlashes', () => {
   it('returns /path for /path', () => {


### PR DESCRIPTION
- Keep HTTP method, query parameters, HTTP body if exists, HTTP request headers the same (except for cookies).
- Make request to `https://api.fpis.io/some_suffix_with_slashes`.
- Respect the region (eu, ap) when making requests.
- Keep HTTP status, body, HTTP response headers the same.
- `Cache-Control` directives are set (`max-age` 60*60, `s-maxage` 60)
- Add tests to cover all new behavior.