### PR TITLE
[INTER-421] feat: remove hard-coded proxy endpoints, introduce config in build

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,6 +7,22 @@ import replace from '@rollup/plugin-replace'
 import nodeResolve from '@rollup/plugin-node-resolve'
 import commonjs from '@rollup/plugin-commonjs'
 
+function getEnv(key, defaultValue) {
+  const value = process.env[key]
+
+  if (!value && !defaultValue) {
+    throw new Error(`Missing environment variable ${key}`)
+  }
+
+  if (!value) {
+    console.warn(`Missing environment variable "${key}". Using default value: ${defaultValue}`)
+
+    return defaultValue
+  }
+
+  return value
+}
+
 const packageJson = require('./package.json')
 
 const inputFile = 'src/index.ts'
@@ -21,12 +37,19 @@ const commonBanner = licensePlugin({
   },
 })
 
+const env = {
+  fpcdn: getEnv('FPCDN', 'fpcdn.io'),
+  ingressApi: getEnv('INGRESS_API', 'api.fpjs.io'),
+}
+
 const commonInput = {
   input: inputFile,
   plugins: [
     replace({
       __current_worker_version__: packageJson.version,
       preventAssignment: true,
+      __FPCDN__: env.fpcdn,
+      __INGRESS_API__: env.ingressApi,
     }),
     jsonPlugin(),
     typescript(),

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,4 @@
+export const config = {
+  fpcdn: '__FPCDN__',
+  ingressApi: '__INGRESS_API__',
+}

--- a/src/utils/proxyEndpoint.ts
+++ b/src/utils/proxyEndpoint.ts
@@ -1,3 +1,5 @@
+import { config } from '../config'
+
 export const DEFAULT_AGENT_VERSION = '3'
 export const DEFAULT_REGION = 'us'
 
@@ -5,7 +7,7 @@ export function getAgentScriptEndpoint(searchParams: URLSearchParams): string {
   const apiKey = searchParams.get('apiKey')
   const apiVersion = searchParams.get('version') || DEFAULT_AGENT_VERSION
 
-  const base = `https://fpcdn.io/v${apiVersion}/${apiKey}`
+  const base = `https://${config.fpcdn}/v${apiVersion}/${apiKey}`
   const loaderVersion = searchParams.get('loaderVersion')
   const lv = loaderVersion ? `/loader_v${loaderVersion}.js` : ''
 
@@ -19,5 +21,5 @@ export function getVisitorIdEndpoint(
   const region = searchParams.get('region') || 'us'
   const prefix = region === DEFAULT_REGION ? '' : `${region}.`
   const suffix = pathSuffix ?? ''
-  return `https://${prefix}api.fpjs.io${suffix}`
+  return `https://${prefix}${config.ingressApi}${suffix}`
 }

--- a/test/endpoints/agentDownload.test.ts
+++ b/test/endpoints/agentDownload.test.ts
@@ -1,5 +1,6 @@
 import worker from '../../src/index'
 import { WorkerEnv } from '../../src/env'
+import { config } from '../../src/config'
 
 const workerEnv: WorkerEnv = {
   PROXY_SECRET: 'proxy_secret',
@@ -36,7 +37,7 @@ describe('agent download request proxy URL', () => {
     const req = new Request(reqURL.toString())
     await worker.fetch(req, workerEnv)
     const receivedURL = new URL(receivedReqURL)
-    expect(receivedURL.origin).toBe('https://fpcdn.io')
+    expect(receivedURL.origin).toBe(`https://${config.fpcdn}`.toLowerCase())
     expect(receivedURL.pathname).toBe('/v3/someApiKey')
   })
 
@@ -45,7 +46,7 @@ describe('agent download request proxy URL', () => {
     const req = new Request(reqURL.toString())
     await worker.fetch(req, workerEnv)
     const receivedURL = new URL(receivedReqURL)
-    expect(receivedURL.origin).toBe('https://fpcdn.io')
+    expect(receivedURL.origin).toBe(`https://${config.fpcdn}`.toLowerCase())
     expect(receivedURL.pathname).toBe('/v4/someApiKey')
   })
 
@@ -55,7 +56,7 @@ describe('agent download request proxy URL', () => {
     const req = new Request(reqURL.toString())
     await worker.fetch(req, workerEnv)
     const receivedURL = new URL(receivedReqURL)
-    expect(receivedURL.origin).toBe('https://fpcdn.io')
+    expect(receivedURL.origin).toBe(`https://${config.fpcdn}`.toLowerCase())
     expect(receivedURL.pathname).toBe('/v5/someApiKey/loader_v1.2.3.js')
   })
 })

--- a/test/endpoints/getResult.test.ts
+++ b/test/endpoints/getResult.test.ts
@@ -1,6 +1,7 @@
 import { WorkerEnv } from '../../src/env'
 import worker from '../../src'
 import { FPJSResponse } from '../../src/utils'
+import { config } from '../../src/config'
 
 const workerEnv: WorkerEnv = {
   PROXY_SECRET: 'proxy_secret',
@@ -36,7 +37,7 @@ describe('ingress API request proxy URL', () => {
     const req = new Request(reqURL.toString(), { method: 'POST' })
     await worker.fetch(req, workerEnv)
     const receivedURL = new URL(receivedReqURL)
-    expect(receivedURL.origin).toBe('https://api.fpjs.io')
+    expect(receivedURL.origin).toBe(`https://${config.ingressApi}`.toLowerCase())
   })
 
   test('us region', async () => {
@@ -44,7 +45,7 @@ describe('ingress API request proxy URL', () => {
     const req = new Request(reqURL.toString(), { method: 'POST' })
     await worker.fetch(req, workerEnv)
     const receivedURL = new URL(receivedReqURL)
-    expect(receivedURL.origin).toBe('https://api.fpjs.io')
+    expect(receivedURL.origin).toBe(`https://${config.ingressApi}`.toLowerCase())
   })
 
   test('eu region', async () => {
@@ -52,7 +53,7 @@ describe('ingress API request proxy URL', () => {
     const req = new Request(reqURL.toString(), { method: 'POST' })
     await worker.fetch(req, workerEnv)
     const receivedURL = new URL(receivedReqURL)
-    expect(receivedURL.origin).toBe('https://eu.api.fpjs.io')
+    expect(receivedURL.origin).toBe(`https://eu.${config.ingressApi}`.toLowerCase())
   })
 
   test('ap region', async () => {
@@ -60,7 +61,7 @@ describe('ingress API request proxy URL', () => {
     const req = new Request(reqURL.toString(), { method: 'POST' })
     await worker.fetch(req, workerEnv)
     const receivedURL = new URL(receivedReqURL)
-    expect(receivedURL.origin).toBe('https://ap.api.fpjs.io')
+    expect(receivedURL.origin).toBe(`https://ap.${config.ingressApi}`.toLowerCase())
   })
 })
 
@@ -92,7 +93,7 @@ describe('ingress API request proxy URL with suffix', () => {
     const req = new Request(reqURL.toString(), { method: 'POST' })
     await worker.fetch(req, workerEnv)
     const receivedURL = new URL(receivedReqURL)
-    expect(receivedURL.origin).toBe('https://api.fpjs.io')
+    expect(receivedURL.origin).toBe(`https://${config.ingressApi}`.toLowerCase())
     expect(receivedURL.pathname).toBe('/suffix/more/path')
   })
 
@@ -101,7 +102,7 @@ describe('ingress API request proxy URL with suffix', () => {
     const req = new Request(reqURL.toString(), { method: 'POST' })
     await worker.fetch(req, workerEnv)
     const receivedURL = new URL(receivedReqURL)
-    expect(receivedURL.origin).toBe('https://api.fpjs.io')
+    expect(receivedURL.origin).toBe(`https://${config.ingressApi}`.toLowerCase())
     expect(receivedURL.pathname).toBe('/suffix/more/path')
   })
 
@@ -110,7 +111,7 @@ describe('ingress API request proxy URL with suffix', () => {
     const req = new Request(reqURL.toString(), { method: 'POST' })
     await worker.fetch(req, workerEnv)
     const receivedURL = new URL(receivedReqURL)
-    expect(receivedURL.origin).toBe('https://eu.api.fpjs.io')
+    expect(receivedURL.origin).toBe(`https://eu.${config.ingressApi}`.toLowerCase())
     expect(receivedURL.pathname).toBe('/suffix/more/path')
   })
 
@@ -119,7 +120,7 @@ describe('ingress API request proxy URL with suffix', () => {
     const req = new Request(reqURL.toString(), { method: 'POST' })
     await worker.fetch(req, workerEnv)
     const receivedURL = new URL(receivedReqURL)
-    expect(receivedURL.origin).toBe('https://ap.api.fpjs.io')
+    expect(receivedURL.origin).toBe(`https://ap.${config.ingressApi}`.toLowerCase())
     expect(receivedURL.pathname).toBe('/suffix/more/path')
   })
 })

--- a/test/utils/proxyEndpoint.test.ts
+++ b/test/utils/proxyEndpoint.test.ts
@@ -1,3 +1,4 @@
+import { config } from '../../src/config'
 import { getAgentScriptEndpoint, getVisitorIdEndpoint } from '../../src/utils'
 
 describe('getAgentScriptEndpoint', () => {
@@ -7,21 +8,21 @@ describe('getAgentScriptEndpoint', () => {
   test('apiKey exists, version does not exist', () => {
     const urlSearchParams = new URLSearchParams()
     urlSearchParams.set('apiKey', apiKey)
-    expect(f(urlSearchParams)).toBe(`https://fpcdn.io/v3/${apiKey}`)
+    expect(f(urlSearchParams)).toBe(`https://${config.fpcdn}/v3/${apiKey}`)
   })
   test('apiKey exists, version exists', () => {
     const version = '4'
     const urlSearchParams = new URLSearchParams()
     urlSearchParams.set('apiKey', apiKey)
     urlSearchParams.set('version', version)
-    expect(f(urlSearchParams)).toBe(`https://fpcdn.io/v${version}/${apiKey}`)
+    expect(f(urlSearchParams)).toBe(`https://${config.fpcdn}/v${version}/${apiKey}`)
   })
   test('apiKey exists, version does not exist, loaderVersion exists', () => {
     const loaderVersion = '3.7.0'
     const urlSearchParams = new URLSearchParams()
     urlSearchParams.set('apiKey', apiKey)
     urlSearchParams.set('loaderVersion', loaderVersion)
-    expect(f(urlSearchParams)).toBe(`https://fpcdn.io/v3/${apiKey}/loader_v${loaderVersion}.js`)
+    expect(f(urlSearchParams)).toBe(`https://${config.fpcdn}/v3/${apiKey}/loader_v${loaderVersion}.js`)
   })
   test('apiKey exists, version exists, loaderVersion exists', () => {
     const version = '4'
@@ -30,31 +31,31 @@ describe('getAgentScriptEndpoint', () => {
     urlSearchParams.set('apiKey', apiKey)
     urlSearchParams.set('version', version)
     urlSearchParams.set('loaderVersion', loaderVersion)
-    expect(f(urlSearchParams)).toBe(`https://fpcdn.io/v${version}/${apiKey}/loader_v${loaderVersion}.js`)
+    expect(f(urlSearchParams)).toBe(`https://${config.fpcdn}/v${version}/${apiKey}/loader_v${loaderVersion}.js`)
   })
 })
 
 describe('getVisitorIdEndpoint', () => {
   test('us region', () => {
     let urlSearchParams = new URLSearchParams()
-    expect(getVisitorIdEndpoint(urlSearchParams)).toBe('https://api.fpjs.io')
+    expect(getVisitorIdEndpoint(urlSearchParams)).toBe(`https://${config.ingressApi}`)
     urlSearchParams = new URLSearchParams()
     urlSearchParams.set('region', 'us')
-    expect(getVisitorIdEndpoint(urlSearchParams)).toBe('https://api.fpjs.io')
+    expect(getVisitorIdEndpoint(urlSearchParams)).toBe(`https://${config.ingressApi}`)
   })
   test('eu region', () => {
     const urlSearchParams = new URLSearchParams()
     urlSearchParams.set('region', 'eu')
-    expect(getVisitorIdEndpoint(urlSearchParams)).toBe('https://eu.api.fpjs.io')
+    expect(getVisitorIdEndpoint(urlSearchParams)).toBe(`https://eu.${config.ingressApi}`)
   })
   test('ap region', () => {
     const urlSearchParams = new URLSearchParams()
     urlSearchParams.set('region', 'ap')
-    expect(getVisitorIdEndpoint(urlSearchParams)).toBe('https://ap.api.fpjs.io')
+    expect(getVisitorIdEndpoint(urlSearchParams)).toBe(`https://ap.${config.ingressApi}`)
   })
   test('no region with suffix', () => {
     const urlSearchParams = new URLSearchParams()
     const pathName = '/suffix/more/path'
-    expect(getVisitorIdEndpoint(urlSearchParams, pathName)).toBe('https://api.fpjs.io/suffix/more/path')
+    expect(getVisitorIdEndpoint(urlSearchParams, pathName)).toBe(`https://${config.ingressApi}/suffix/more/path`)
   })
 })


### PR DESCRIPTION
- Introduce config with URLs to our APIs, similar to how it is done in CloudFront and Azure integration
- Introduce a check in the build process that fails whenever any required env variable is missing