### PR TITLE
test(e2e): worker version matches now matches more cases

### DIFF
--- a/test/e2e/visitorId.spec.ts
+++ b/test/e2e/visitorId.spec.ts
@@ -33,7 +33,7 @@ test.describe('visitorId', () => {
     try {
       const responseBody = await res.text()
       if (responseBody.includes('Your Cloudflare worker is deployed')) {
-        const matches = responseBody.match(/Worker version: ([\d.\-snaphot]+)/)
+        const matches = responseBody.match(/Worker version: (.+)/)
         if (matches && matches.length > 0) {
           const version = matches[1]
           if (version === expectedVersion) {


### PR DESCRIPTION
Fixes the problem where the worker version is `1.5.0-rc.1` and e2e tests fail.