### PR TITLE
[Pseudo-IPv4] Fix client IP resolution in addProxyIntegrationHeaders INTER-1139

### DIFF
--- a/src/utils/addProxyIntegrationHeaders.ts
+++ b/src/utils/addProxyIntegrationHeaders.ts
@@ -2,9 +2,21 @@ import { getProxySecret, WorkerEnv } from '../env'
 
 export function addProxyIntegrationHeaders(headers: Headers, url: string, env: WorkerEnv) {
   const proxySecret = getProxySecret(env)
-  if (proxySecret) {
-    headers.set('FPJS-Proxy-Secret', proxySecret)
-    headers.set('FPJS-Proxy-Client-IP', headers.get('CF-Connecting-IP') || '')
-    headers.set('FPJS-Proxy-Forwarded-Host', new URL(url).hostname)
+  if (!proxySecret) {
+    return
   }
+
+  headers.set('FPJS-Proxy-Secret', proxySecret)
+  headers.set('FPJS-Proxy-Client-IP', getIPFromHeaders(headers))
+  headers.set('FPJS-Proxy-Forwarded-Host', new URL(url).hostname)
+}
+
+export function getIPFromHeaders(headers: Headers) {
+  const connectingIP = headers.get('CF-Connecting-IP')
+
+  if (headers.get('Cf-Pseudo-IPv4') === connectingIP) {
+    return headers.get('CF-Connecting-IPv6') || ''
+  }
+
+  return connectingIP || ''
 }

--- a/src/utils/addProxyIntegrationHeaders.ts
+++ b/src/utils/addProxyIntegrationHeaders.ts
@@ -14,6 +14,7 @@ export function addProxyIntegrationHeaders(headers: Headers, url: string, env: W
 export function getIPFromHeaders(headers: Headers) {
   const connectingIP = headers.get('CF-Connecting-IP')
 
+  // Correctly handle CloudFlare's [Pseudo IPv4](https://developers.cloudflare.com/network/pseudo-ipv4/) feature set to `Overwrite headers`
   if (headers.get('Cf-Pseudo-IPv4') === connectingIP) {
     return headers.get('CF-Connecting-IPv6') || ''
   }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -12,7 +12,7 @@ export {
   addTrafficMonitoringSearchParamsForProCDN,
 } from './addTrafficMonitoring'
 export { returnHttpResponse } from './returnHttpResponse'
-export { addProxyIntegrationHeaders } from './addProxyIntegrationHeaders'
+export { addProxyIntegrationHeaders, getIPFromHeaders } from './addProxyIntegrationHeaders'
 export { filterCookies } from './cookie'
 export {
   createRoute,

--- a/test/utils/addProxyIntegrationHeaders.test.ts
+++ b/test/utils/addProxyIntegrationHeaders.test.ts
@@ -70,6 +70,13 @@ describe('getIPFromHeaders', () => {
     expect(getIPFromHeaders(headers)).toEqual(ipv6)
   })
 
+  it('returns an empty string when CF-Connecting-IP header is set to an empty string', () => {
+    const headers = new Headers()
+    headers.set('CF-Connecting-IP', '')
+
+    expect(getIPFromHeaders(headers)).toEqual('')
+  })
+
   it('returns an empty string when no headers are set', () => {
     expect(getIPFromHeaders(new Headers())).toEqual('')
   })

--- a/test/utils/addProxyIntegrationHeaders.test.ts
+++ b/test/utils/addProxyIntegrationHeaders.test.ts
@@ -1,12 +1,16 @@
 import { addProxyIntegrationHeaders, getIPFromHeaders } from '../../src/utils'
 import { WorkerEnv } from '../../src/env'
 
+const ipv6 = '84D:1111:222:3333:4444:5555:6:77'
+const ipv4 = '19.117.63.126'
+
 describe('addProxyIntegrationHeaders', () => {
   let headers: Headers
   let env: WorkerEnv
+
   beforeEach(() => {
     headers = new Headers()
-    headers.set('CF-Connecting-IP', '19.117.63.126')
+    headers.set('CF-Connecting-IP', ipv4)
     headers.set('x-custom-header', 'custom-value')
     env = {
       AGENT_SCRIPT_DOWNLOAD_PATH: 'agent-path',
@@ -16,14 +20,16 @@ describe('addProxyIntegrationHeaders', () => {
       FPJS_INGRESS_BASE_HOST: null,
     }
   })
-  test('when PROXY_SECRET is set', () => {
+
+  it('append proxy headers when PROXY_SECRET is set', () => {
     addProxyIntegrationHeaders(headers, 'https://example.com/worker/result', env)
     expect(headers.get('FPJS-Proxy-Secret')).toBe('secret_value')
-    expect(headers.get('FPJS-Proxy-Client-IP')).toBe('19.117.63.126')
+    expect(headers.get('FPJS-Proxy-Client-IP')).toBe(ipv4)
     expect(headers.get('FPJS-Proxy-Forwarded-Host')).toBe('example.com')
     expect(headers.get('x-custom-header')).toBe('custom-value')
   })
-  test('when PROXY_SECRET is not set', () => {
+
+  test('not append proxy headers when PROXY_SECRET is not set', () => {
     env.PROXY_SECRET = null
     addProxyIntegrationHeaders(headers, 'https://example.com/worker/result', env)
     expect(headers.get('FPJS-Proxy-Secret')).toBe(null)
@@ -31,20 +37,33 @@ describe('addProxyIntegrationHeaders', () => {
     expect(headers.get('FPJS-Proxy-Forwarded-Host')).toBe(null)
     expect(headers.get('x-custom-header')).toBe('custom-value')
   })
-  test('ipv6', () => {
-    headers.set('CF-Connecting-IP', '84D:1111:222:3333:4444:5555:6:77')
+
+  test('use ipv6 when connecting ip is ipv6', () => {
+    headers.set('CF-Connecting-IP', ipv6)
     addProxyIntegrationHeaders(headers, 'https://example.com/worker/result', env)
     expect(headers.get('FPJS-Proxy-Secret')).toBe('secret_value')
-    expect(headers.get('FPJS-Proxy-Client-IP')).toBe('84D:1111:222:3333:4444:5555:6:77')
+    expect(headers.get('FPJS-Proxy-Client-IP')).toBe(ipv6)
     expect(headers.get('FPJS-Proxy-Forwarded-Host')).toBe('example.com')
     expect(headers.get('x-custom-header')).toBe('custom-value')
+  })
+
+  test('use CF-Connecting-IP as FPJS-Proxy-Client-IP when Cf-Pseudo-IPv4 is present but different', () => {
+    headers.set('CF-Connecting-IP', ipv6)
+    headers.set('Cf-Pseudo-IPv4', ipv4)
+    addProxyIntegrationHeaders(headers, 'https://example.com/worker/result', env)
+    expect(headers.get('FPJS-Proxy-Client-IP')).toBe(ipv6)
+  })
+
+  test('use CF-Connecting-IPv6 as FPJS-Proxy-Client-IP when Cf-Pseudo-IPv4 matches CF-Connecting-IP', () => {
+    headers.set('CF-Connecting-IP', ipv4)
+    headers.set('Cf-Pseudo-IPv4', ipv4)
+    headers.set('CF-Connecting-IPv6', ipv6)
+    addProxyIntegrationHeaders(headers, 'https://example.com/worker/result', env)
+    expect(headers.get('FPJS-Proxy-Client-IP')).toBe(ipv6)
   })
 })
 
 describe('getIPFromHeaders', () => {
-  const ipv6 = '2001:67c:198c:906:3b::3c2'
-  const ipv4 = '19.117.63.126'
-
   it('returns CF-Connecting-IP when only CF-Connecting-IP is set', () => {
     const headers = new Headers()
     headers.set('CF-Connecting-IP', ipv4)

--- a/test/utils/addProxyIntegrationHeaders.test.ts
+++ b/test/utils/addProxyIntegrationHeaders.test.ts
@@ -1,6 +1,5 @@
-import { addProxyIntegrationHeaders } from '../../src/utils'
+import { addProxyIntegrationHeaders, getIPFromHeaders } from '../../src/utils'
 import { WorkerEnv } from '../../src/env'
-import { getIPFromHeaders } from '../../src/utils/addProxyIntegrationHeaders'
 
 describe('addProxyIntegrationHeaders', () => {
   let headers: Headers


### PR DESCRIPTION
This PR fixes how the client IP is determined in `addProxyIntegrationHeaders`. Previously, `FPJS-Proxy-Client-IP` could be set incorrectly when Cloudflare's [Pseudo IPv4][cf-pseudo-ipv4] feature was enabled.

## What's Changed?

- Now correctly prioritizes `CF-Connecting-IPv6` when `Cf-Pseudo-IPv4` matches `CF-Connecting-IP`.
- Added an early return when `proxySecret` isn't set.
- Implemented a new `getIPFromHeaders` function to handle IP resolution.
- Added unit tests.

## Why This Matters?

This fix ensures that when Cloudflare's `Overwrite Headers` option is enabled, the correct client IP is used.

## How To Test?

- Run `pnpm test` to verify all unit tests pass.
- Try different header combinations (`CF-Connecting-IP`, `CF-Connecting-IPv6`, `Cf-Pseudo-IPv4`) and confirm expected result.

Let me know if anything needs adjusting! 😇 

[cf-pseudo-ipv4]: https://developers.cloudflare.com/network/pseudo-ipv4/