### PR TITLE
INTER-1163 Update wrangler-action to v3

### DIFF
--- a/.github/workflows/teste2e-release.yml
+++ b/.github/workflows/teste2e-release.yml
@@ -40,6 +40,7 @@ jobs:
         id: random-path-generator
       - name: Modify wrangler.toml
         run: |
+           sed -i '/^account_id = ""$/d' wrangler.toml
            sed -i 's/name = .*/name = "${{steps.random-path-generator.outputs.WORKER_NAME}}"/' wrangler.toml
            sed -i 's/route = .*/route = "${{ secrets.TEST_CLIENT_DOMAIN }}\/${{steps.random-path-generator.outputs.WORKER_PATH}}\/*"/' wrangler.toml
            echo [vars] >> wrangler.toml
@@ -51,9 +52,8 @@ jobs:
           
            cat wrangler.toml
       - name: Publish
-        uses: cloudflare/wrangler-action@2.0.0
+        uses: cloudflare/wrangler-action@v3
         with:
-          command: publish
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
       - name: Get version


### PR DESCRIPTION
The `cloudflare/wrangler-action` version has been updated from `2.0.0` to `v3`. Also, removed `account_id` line from `wrangler.toml` file with `sed` to prevent warning message in the output ([like this one](https://github.com/fingerprintjs/fingerprintjs-pro-cloudflare-worker/actions/runs/13923100264/job/38961140975#step:8:93)).