### PR TITLE
Fix e2e tests version bump INTER-1205

### DIFF
--- a/.github/workflows/teste2e.yml
+++ b/.github/workflows/teste2e.yml
@@ -7,16 +7,6 @@ on:
   schedule:
     - cron: '30 1 * * *'
   workflow_dispatch:
-    inputs:
-      version_bump:
-        description: 'A type of version bump'
-        default: 'patch'
-        required: true
-        type: choice
-        options:
-          - major
-          - minor
-          - patch
 
 jobs:
   build-and-deploy-and-test-e2e-mock:
@@ -40,8 +30,7 @@ jobs:
 
       - name: Upgrade version
         run: |
-          version_bump=${{ github.event.inputs.version_bump || 'patch' }}
-          pnpm version $version_bump --preid snapshot --no-git-tag
+          pnpm version prerelease --preid snapshot --no-commit-hooks --no-git-tag-version --ignore-scripts
 
       - name: Generate random paths
         run: |
@@ -118,8 +107,7 @@ jobs:
 
       - name: Upgrade version
         run: |
-          version_bump=${{ github.event.inputs.version_bump || 'patch' }}
-          pnpm version $version_bump --preid snapshot --no-git-tag
+          pnpm version prerelease --preid snapshot --no-commit-hooks --no-git-tag-version --ignore-scripts
       - name: Generate random paths
         run: |
           postfix=$(date +%s)

--- a/test/e2e/visitorId.spec.ts
+++ b/test/e2e/visitorId.spec.ts
@@ -69,6 +69,7 @@ test.describe('visitorId', () => {
   }
 
   async function runTest(page: Page, url: string) {
+    console.log(`Running goto url: ${url}...`)
     await page.goto(url, {
       waitUntil: 'networkidle',
     })


### PR DESCRIPTION
This PR fixes a problem which starting happening when we switched from `yarn` to `pnpm`. The test version is bumped as PATCH and `preid` flag did not work.

We always used `patch` to bump the version so far, as a result I've removed the selection from `workflow_dispatch` as well because I could not use the input in the `pnpm` command.