### PR TITLE
[CI] Update GitHub Action runners to ubuntu-24.04

### DIFF
--- a/.github/workflows/teste2e-release.yml
+++ b/.github/workflows/teste2e-release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test-release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: Test release
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/teste2e.yml
+++ b/.github/workflows/teste2e.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-and-deploy-and-test-e2e-mock:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: Build & Deploy & Test e2e using mock app
 
     steps:
@@ -88,7 +88,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   build-and-deploy-and-test-e2e:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: Build & Deploy & Test e2e
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Replaced all instances of `runs-on: ubuntu-20.04` with `ubuntu-24.04` in the E2E test workflows (`teste2e-release`, `teste2e`). This change keeps our CI environment up to date with the latest LTS version.

We're explicitly using `ubuntu-24.04` instead of `ubuntu-latest` to avoid unexpected changes when GitHub updates the default version. This way, version upgrades become intentional. If something breaks, it happens at the time we upgrade, making it much easier to debug and fix compared to random failures caused by `-latest` version change.