### PR TITLE
ci: set Datadog team in e2e test workflows

### DIFF
--- a/.github/workflows/teste2e-release.yml
+++ b/.github/workflows/teste2e-release.yml
@@ -6,6 +6,14 @@ on:
       - published
 
 jobs:
+  set_datadog_team:
+    name: 'Set Datadog team and release tag'
+    uses: fingerprintjs/dx-team-toolkit/.github/workflows/set-datadog-team.yml@v1
+    with:
+      additionalTags: 'release-tag-name:${{ github.event.release.tag_name }}'
+    secrets:
+      DD_API_KEY: ${{ secrets.INTEGRATIONS_DATADOG_API_KEY }}
+
   test-release:
     runs-on: ubuntu-24.04
     name: Test release

--- a/.github/workflows/teste2e.yml
+++ b/.github/workflows/teste2e.yml
@@ -9,6 +9,12 @@ on:
   workflow_dispatch:
 
 jobs:
+  set_datadog_team:
+    name: Set Datadog team
+    uses: fingerprintjs/dx-team-toolkit/.github/workflows/set-datadog-team.yml@v1
+    secrets:
+      DD_API_KEY: ${{ secrets.INTEGRATIONS_DATADOG_API_KEY }}
+  
   build-and-deploy-and-test-e2e-mock:
     runs-on: ubuntu-24.04
     name: Build & Deploy & Test e2e using mock app
@@ -78,14 +84,6 @@ jobs:
       - name: Clean up worker
         run: |
           curl -i -X DELETE "https://api.cloudflare.com/client/v4/accounts/${{secrets.CF_ACCOUNT_ID}}/workers/scripts/${{steps.random-path-generator.outputs.WORKER_NAME}}" -H"Authorization: bearer ${{secrets.CF_API_TOKEN}}"
-      - name: Report Status
-        if: always()
-        uses: ravsamhq/notify-slack-action@0d9c6ff1de9903da88d24c0564f6e83cb28faca9
-        with:
-          status: ${{ job.status }}
-          notification_title: "Cloudflare Worker E2E Test using mock app has {status_message}"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   build-and-deploy-and-test-e2e:
     runs-on: ubuntu-24.04
@@ -149,11 +147,3 @@ jobs:
       - name: Clean up worker
         run: |
           curl -i -X DELETE "https://api.cloudflare.com/client/v4/accounts/${{secrets.CF_ACCOUNT_ID}}/workers/scripts/${{steps.random-path-generator.outputs.WORKER_NAME}}" -H"Authorization: bearer ${{secrets.CF_API_TOKEN}}"
-      - name: Report Status
-        if: always()
-        uses: ravsamhq/notify-slack-action@0d9c6ff1de9903da88d24c0564f6e83cb28faca9
-        with:
-          status: ${{ job.status }}
-          notification_title: "Cloudflare Worker E2E Test has {status_message}"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
The release workflow also sets the release-tag-name tag that will be used by a Datadog monitor for sending notifications with the result of this workflow.