### PR TITLE
chore: update repo references to use `cloudflare-worker-proxy` name

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,7 +3,7 @@
   "changelog": [
     "@fingerprintjs/changesets-changelog-format",
     {
-      "repo": "fingerprintjs/fingerprintjs-pro-cloudflare-worker"
+      "repo": "fingerprintjs/cloudflare-worker-proxy"
     }
   ],
   "commit": false,

--- a/.github/workflows/teste2e-release.yml
+++ b/.github/workflows/teste2e-release.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           mkdir -p e2e-deploy
           cp dist/*/wrangler.json e2e-deploy
-          cp fingerprintjs-pro-cloudflare-worker.esm.js e2e-deploy/index.js
+          cp fingerprint-cloudflare-worker-proxy.js e2e-deploy/index.js
 
       - name: Generate random paths
         run: |

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
    </picture>
   </a>
 <p align="center">
-<a href="https://github.com/fingerprintjs/fingerprintjs-pro-cloudflare-worker"><img src="https://img.shields.io/github/v/release/fingerprintjs/fingerprintjs-pro-cloudflare-worker" alt="Current NPM version"></a>
-<a href="https://fingerprintjs.github.io/fingerprintjs-pro-cloudflare-worker/"><img src="https://raw.githubusercontent.com/fingerprintjs/fingerprintjs-pro-cloudflare-worker/gh-pages/badges.svg" alt="coverage"></a>
+<a href="https://github.com/fingerprintjs/cloudflare-worker-proxy"><img src="https://img.shields.io/github/v/release/fingerprintjs/cloudflare-worker-proxy" alt="Current NPM version"></a>
+<a href="https://fingerprintjs.github.io/cloudflare-worker-proxy/"><img src="https://raw.githubusercontent.com/fingerprintjs/cloudflare-worker-proxy/gh-pages/badges.svg" alt="coverage"></a>
 <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/:license-mit-blue.svg" alt="MIT license"></a>
 <a href="https://discord.gg/39EpE2neBg"><img src="https://img.shields.io/discord/852099967190433792?style=logo&label=Discord&logo=Discord&logoColor=white" alt="Discord server"></a>
 
@@ -39,8 +39,8 @@ See the [Cloudflare integration guide](https://dev.fingerprint.com/docs/cloudfla
 
 ## Support
 
-To report problems, ask questions or provide feedback, please use [Issues](https://github.com/fingerprintjs/fingerprintjs-pro-cloudflare-worker/issues). If you need private support, you can email us at [oss-support@fingerprint.com](mailto:oss-support@fingerprint.com).
+To report problems, ask questions or provide feedback, please use [Issues](https://github.com/fingerprintjs/cloudflare-worker-proxy/issues). If you need private support, you can email us at [oss-support@fingerprint.com](mailto:oss-support@fingerprint.com).
 
 ## License
 
-This project is licensed under the MIT license. See the [LICENSE](https://github.com/fingerprintjs/fingerprintjs-pro-cloudflare-worker/blob/main/LICENSE) file for more info.
+This project is licensed under the MIT license. See the [LICENSE](https://github.com/fingerprintjs/cloudflare-worker-proxy/blob/main/LICENSE) file for more info.

--- a/contributing.md
+++ b/contributing.md
@@ -22,7 +22,7 @@ Create pull requests for the `main` branch.
 ### How to build
 After cloning the repo, run `pnpm install` to install packages.
 
-Run `pnpm build` for creating a build in `dist` folder. After building, `dist/fingerprintjs-pro-cloudflare-worker.esm.js` file is created, and it is used to deploy to CF.
+Run `pnpm build` for creating a build in `dist` folder. The build creates the worker script file, located at `dist/fingerprint_pro_cloudflare_worker_local_development/index.js`.
 
 ### How to run locally
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "sideEffects": false,
   "repository": {
     "type": "git",
-    "url": "https://github.com/fingerprintjs/fingerprintjs-pro-cloudflare-worker.git"
+    "url": "https://github.com/fingerprintjs/cloudflare-worker-proxy.git"
   },
   "exports": {
     "./worker": "./dist/fingerprint_pro_cloudflare_worker_local_development/index.js"

--- a/scripts/downloadGitHubRelease.mjs
+++ b/scripts/downloadGitHubRelease.mjs
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'url'
 const config = {
   token: process.env.GITHUB_TOKEN,
   owner: 'fingerprintjs',
-  repo: 'fingerprintjs-pro-cloudflare-worker',
+  repo: 'cloudflare-worker-proxy',
 }
 
 const dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -86,7 +86,7 @@ async function downloadReleaseAsset(url, token) {
 }
 
 async function findReleaseAsset(assets) {
-  const targetAssetsName = 'fingerprintjs-pro-cloudflare-worker.esm.js'
+  const targetAssetsName = 'fingerprint-cloudflare-worker-proxy.js'
 
   const targetAsset = assets.find((asset) => asset.name === targetAssetsName && asset.state === 'uploaded')
 


### PR DESCRIPTION
Rename references to the repo name in preparation for renaming it.

When we are ready to merge this PR, we should first rename the repo immediately before merging.